### PR TITLE
Fix failing tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ FAA‑style validation for Word docs—CLI, FastAPI, and React UI in one toolkit
 * a **FastAPI** backend (live Swagger UI)
 * a modern **React/Next.js** frontend with real‑time preview
 * an easy **CLI** for local batch checks
+* Displays document metadata (Title, Author, Last Modified By, Created, Modified)
 
 Full technical docs live under **`docs/`**; start with *docs/getting‑started.md* when you’re ready to dig deeper.
 

--- a/src/govdocverify/logging_config.py
+++ b/src/govdocverify/logging_config.py
@@ -87,3 +87,16 @@ def setup_logging(debug: bool = False) -> None:
         logging.config.dictConfig(LOGGING_CONFIG)
     else:
         logging.config.dictConfig(LOGGING_CONFIG_INFO)
+
+    # Ensure all StreamHandlers use UTF-8 after configuration
+    root_logger = logging.getLogger()
+    for handler in root_logger.handlers:
+        if isinstance(handler, logging.StreamHandler):
+            stream = handler.stream
+            if hasattr(stream, "reconfigure"):
+                try:
+                    stream.reconfigure(encoding="utf-8", errors="replace")
+                    continue
+                except Exception:  # pragma: no cover - platform dependent
+                    pass
+            handler.stream = TextIOWrapper(stream.buffer, encoding="utf-8", errors="replace")

--- a/tests/property/test_export_prop.py
+++ b/tests/property/test_export_prop.py
@@ -10,7 +10,11 @@ from govdocverify import export
 
 @pytest.mark.property
 @given(
-    results=st.dictionaries(keys=st.text(min_size=1, max_size=10), values=st.integers()),
+    results=st.dictionaries(
+        keys=st.text(min_size=1, max_size=10),
+        values=st.integers(),
+        max_size=5,
+    ),
     file_name=st.text(
         min_size=1, max_size=10, alphabet=st.characters(min_codepoint=97, max_codepoint=122)
     ),
@@ -26,7 +30,11 @@ def test_save_results_as_docx_property(
 
 @pytest.mark.property
 @given(
-    results=st.dictionaries(keys=st.text(min_size=1, max_size=10), values=st.integers()),
+    results=st.dictionaries(
+        keys=st.text(min_size=1, max_size=10),
+        values=st.integers(),
+        max_size=5,
+    ),
     file_name=st.text(
         min_size=1, max_size=10, alphabet=st.characters(min_codepoint=97, max_codepoint=122)
     ),


### PR DESCRIPTION
## Summary
- reduce property-based dict sizes to avoid Hypothesis health check failures
- ensure log stream encoding stays UTF-8 across handlers
- document metadata fields in README

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src tests`
- `bandit -r src -lll --skip B101` *(fails: command not found)*
- `semgrep --config p/ci` *(fails: command not found)*
- `pytest -q --cov=src --cov-branch --cov-fail-under=70` *(fails: plugin not installed)*
- `pytest -q -m property` *(fails: missing dependencies)*
- `pytest -q -m e2e` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688bc1cd00c88332a28dfc8b9ecf5c1f