### PR TITLE
Fix coverage instructions

### DIFF
--- a/.dev/AGENTS.md
+++ b/.dev/AGENTS.md
@@ -72,7 +72,7 @@ black --check src tests
 mypy --strict src tests
 bandit -r src -lll --skip B101               # allow asserts early
 semgrep --config p/ci                       # lightweight SAST
-pytest -q --cov=src --cov-branch --cov-fail-under=70
+pytest -q --cov=govdocverify --cov-branch --cov-fail-under=70
 pytest -q -m property                       # Hypothesis tests
 pytest -q -m e2e                            # Playwright (headless)
 ```
@@ -86,7 +86,7 @@ mypy --strict src tests
 bandit -r src -lll
 semgrep --config p/default
 pip-audit -r requirements.txt
-pytest -q --cov=src --cov-branch --cov-fail-under=90
+pytest -q --cov=govdocverify --cov-branch --cov-fail-under=90
 pytest -q -m e2e
 trivy fs --exit-code 1 --severity CRITICAL,HIGH .
 mkdocs build --strict

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ pre-commit run --all-files   # Run all checks across the codebase
 Run the full test suite with code coverage reporting using pytest:
 
 ```bash
-pytest --cov=src
+pytest --cov=govdocverify
 ```
 
 * Replace `src` with your module's directory if different.
@@ -223,7 +223,7 @@ mutmut results
 
 ```bash
 pre-commit run --all-files        # Lint, format, type check, spellcheck, markdown, security
-pytest --cov=src                  # Unit tests with coverage
+pytest --cov=govdocverify         # Unit tests with coverage
 bandit -r src -lll --skip B101    # Security scan (code)
 pip-audit                         # Security scan (dependencies)
 codespell src tests docs          # Spell check (if not running in pre-commit)
@@ -247,7 +247,7 @@ mutmut results
 | mdformat     | Markdown formatting/linting | `pre-commit run --all-files`                  |
 | docformatter | Docstring style (optional)  | `docformatter -r src/`                        |
 | Mutmut       | Mutation test (optional)    | `mutmut run --paths-to-mutate src`            |
-| Pytest       | Unit tests/coverage         | `pytest --cov=src`                            |
+| Pytest       | Unit tests/coverage         | `pytest --cov=govdocverify`                            |
 | Safety       | Security (deps, optional)   | `safety check`                                |
 
 ---

--- a/src/govdocverify/checks/format_checks.py
+++ b/src/govdocverify/checks/format_checks.py
@@ -209,7 +209,7 @@ class FormatChecks(BaseChecker):
         for i, text in enumerate(paragraphs):
             for pattern in placeholder_patterns:
                 if re.search(pattern, text, re.IGNORECASE):
-                    logger.debug(f"Found placeholder in line {i+1}: {text}")
+                    logger.debug(f"Found placeholder in line {i + 1}: {text}")
                     try:
                         results.add_issue(
                             FormatMessages.PLACEHOLDER_ERROR,
@@ -217,7 +217,7 @@ class FormatChecks(BaseChecker):
                             i + 1,
                             category=getattr(self, "category", "format"),
                         )
-                        logger.debug(f"Successfully added issue for line {i+1}")
+                        logger.debug(f"Successfully added issue for line {i + 1}")
                         break  # Only add one issue per line
                     except Exception as e:
                         logger.error(f"Error adding issue: {str(e)}")
@@ -238,7 +238,7 @@ class FormatChecks(BaseChecker):
             for pattern, message in dash_patterns:
                 if matches := re.finditer(pattern, text):
                     for match in matches:
-                        logger.debug(f"Found dash spacing issue in line {i+1}: {text}")
+                        logger.debug(f"Found dash spacing issue in line {i + 1}: {text}")
                         try:
                             results.add_issue(
                                 message,
@@ -246,7 +246,7 @@ class FormatChecks(BaseChecker):
                                 i + 1,
                                 category=getattr(self, "category", "format"),
                             )
-                            logger.debug(f"Successfully added issue for line {i+1}")
+                            logger.debug(f"Successfully added issue for line {i + 1}")
                         except Exception as e:
                             logger.error(f"Error adding issue: {str(e)}")
                             logger.error(f"Error type: {type(e)}")
@@ -749,11 +749,11 @@ class FormattingChecker(BaseChecker):
         for i, text in enumerate(lines):
             # Skip if text matches any skip patterns
             if any(re.search(pattern, text) for pattern in DATE_PATTERNS["skip_patterns"]):
-                logger.debug(f"[Text] Skipping line {i+1} due to skip pattern: {text!r}")
+                logger.debug(f"[Text] Skipping line {i + 1} due to skip pattern: {text!r}")
                 continue
             # Check for incorrect date format (MM/DD/YYYY)
             if re.search(DATE_PATTERNS["incorrect"], text):
-                logger.debug(f"[Text] Found incorrect date format in line {i+1}: {text!r}")
+                logger.debug(f"[Text] Found incorrect date format in line {i + 1}: {text!r}")
                 issues.append(
                     {
                         "message": FormatMessages.DATE_FORMAT_ERROR,

--- a/src/govdocverify/checks/heading_checks.py
+++ b/src/govdocverify/checks/heading_checks.py
@@ -174,8 +174,7 @@ class HeadingChecks(BaseChecker):
                     "type": "length_violation",
                     "line": line,
                     "message": (
-                        f"Heading exceeds maximum length of "
-                        f"{self.MAX_HEADING_LENGTH} characters."
+                        f"Heading exceeds maximum length of {self.MAX_HEADING_LENGTH} characters."
                     ),
                     "suggestion": (
                         f"Shorten heading to {self.MAX_HEADING_LENGTH} characters or less."
@@ -258,7 +257,7 @@ class HeadingChecks(BaseChecker):
                 {
                     "type": "missing_headings",
                     "missing": list(missing_headings),
-                    "message": f'Missing required headings: {", ".join(missing_headings)}',
+                    "message": f"Missing required headings: {', '.join(missing_headings)}",
                     "severity": Severity.ERROR,
                     "category": self.category,
                 }
@@ -468,8 +467,7 @@ class HeadingChecks(BaseChecker):
     ) -> None:
         """Add issue for level skipping."""
         logger.warning(
-            f"Invalid heading sequence in paragraph {paragraph_num}: "
-            f"skipped level {prev_level + 1}"
+            f"Invalid heading sequence in paragraph {paragraph_num}: skipped level {prev_level + 1}"
         )
         issues.append(
             {
@@ -510,13 +508,13 @@ class HeadingChecks(BaseChecker):
     ) -> None:
         """Add issue for incorrect sequence numbering."""
         logger.warning(
-            f"Invalid heading sequence in paragraph {paragraph_num}: " f"expected {prev_last + 1}"
+            f"Invalid heading sequence in paragraph {paragraph_num}: expected {prev_last + 1}"
         )
         issues.append(
             {
                 "text": text,
                 "message": f"Invalid heading sequence: expected {prev_last + 1}",
-                "suggestion": f'Use {".".join(numbers[:-1] + [str(prev_last + 1)])}',
+                "suggestion": f"Use {'.'.join(numbers[:-1] + [str(prev_last + 1)])}",
                 "category": self.category,
             }
         )

--- a/src/govdocverify/checks/reference_checks.py
+++ b/src/govdocverify/checks/reference_checks.py
@@ -25,7 +25,7 @@ class ReferenceMessages:
 
     # Numbering format messages
     TABLE_FIGURE_NUMBERING = (
-        "Use '{ref_type} X-Y' for ACs and Orders, " "or '{ref_type} X' for other document types."
+        "Use '{ref_type} X-Y' for ACs and Orders, or '{ref_type} X' for other document types."
     )
 
     # Document title format messages

--- a/src/govdocverify/checks/structure_checks.py
+++ b/src/govdocverify/checks/structure_checks.py
@@ -1016,7 +1016,7 @@ class StructureChecks(BaseChecker):
             if re.search(pattern, line, re.IGNORECASE):
                 result["warnings"].append({"message": message, "line_number": line_num})
                 logger.debug(
-                    f"Added capitalization warning for line {line_num}: " f"should be capitalized"
+                    f"Added capitalization warning for line {line_num}: should be capitalized"
                 )
 
     def _check_spacing_issues(self, line: str, line_num: int, result: Dict[str, Any]):

--- a/src/govdocverify/checks/terminology_checks.py
+++ b/src/govdocverify/checks/terminology_checks.py
@@ -67,7 +67,7 @@ class TerminologyChecks(BaseChecker):
     def _check_consistency(self, paragraphs: list[str], results: DocumentCheckResult) -> None:
         """Check for consistent terminology usage."""
         for i, text in enumerate(paragraphs):
-            logger.debug(f"[Terminology] Checking line {i+1}: {text!r}")
+            logger.debug(f"[Terminology] Checking line {i + 1}: {text!r}")
             for standard, variants in TERMINOLOGY_VARIANTS.items():
                 for variant in variants:
                     pattern = rf"\b{re.escape(variant)}\b"
@@ -75,7 +75,7 @@ class TerminologyChecks(BaseChecker):
                     if re.search(pattern, text, flags):
                         logger.debug(
                             f"[Terminology] Matched variant '{variant}' (should use '{standard}') "
-                            f"in line {i+1}"
+                            f"in line {i + 1}"
                         )
                         results.add_issue(
                             message=TerminologyMessages.INCONSISTENT_TERMINOLOGY.format(
@@ -89,9 +89,9 @@ class TerminologyChecks(BaseChecker):
     def _check_forbidden_terms(self, paragraphs: list[str], results: DocumentCheckResult) -> None:
         """Check for forbidden or discouraged terms."""
         for i, text in enumerate(paragraphs):
-            logger.debug(f"[Terminology] Checking forbidden terms in line {i+1}: {text!r}")
+            logger.debug(f"[Terminology] Checking forbidden terms in line {i + 1}: {text!r}")
             if ABOVE_BELOW_REF_PATTERN.search(text):
-                logger.debug(f"[Terminology] Matched relative reference in line {i+1}")
+                logger.debug(f"[Terminology] Matched relative reference in line {i + 1}")
                 results.add_issue(
                     message=TerminologyMessages.ABOVE_BELOW_WARNING,
                     severity=Severity.WARNING,
@@ -101,7 +101,7 @@ class TerminologyChecks(BaseChecker):
             for term, message in FORBIDDEN_TERMS.items():
                 pattern = rf"\b{re.escape(term)}\b"
                 if re.search(pattern, text, re.IGNORECASE):
-                    logger.debug(f"[Terminology] Matched forbidden term '{term}' in line {i+1}")
+                    logger.debug(f"[Terminology] Matched forbidden term '{term}' in line {i + 1}")
                     results.add_issue(
                         message=message,
                         severity=Severity.WARNING,
@@ -115,7 +115,7 @@ class TerminologyChecks(BaseChecker):
         TERM_REPLACEMENTS.  Suggest the approved wording.
         """
         for i, text in enumerate(paragraphs):
-            logger.debug(f"[Terminology] Checking term replacements in line {i+1}: {text!r}")
+            logger.debug(f"[Terminology] Checking term replacements in line {i + 1}: {text!r}")
             for obsolete, approved in TERM_REPLACEMENTS.items():
                 # Handle special cases that need different regex patterns
                 if obsolete in [
@@ -144,7 +144,9 @@ class TerminologyChecks(BaseChecker):
                     pattern = rf"\b{re.escape(obsolete)}\b"
 
                 if re.search(pattern, text, re.IGNORECASE):
-                    logger.debug(f"[Terminology] Matched obsolete term '{obsolete}' in line {i+1}")
+                    logger.debug(
+                        f"[Terminology] Matched obsolete term '{obsolete}' in line {i + 1}"
+                    )
                     results.add_issue(
                         message=f'Change "{obsolete}" to "{approved}"',
                         severity=Severity.WARNING,

--- a/src/govdocverify/formatting/document_formatter.py
+++ b/src/govdocverify/formatting/document_formatter.py
@@ -122,7 +122,7 @@ class DocumentFormatter:
                 issues.append(
                     {
                         "type": "formatting",
-                        "message": f"Incorrect list indentation on line {i+1}",
+                        "message": f"Incorrect list indentation on line {i + 1}",
                         "suggestion": "Indent list items with 4 spaces",
                     }
                 )

--- a/tests/test_structure_checks.py
+++ b/tests/test_structure_checks.py
@@ -267,7 +267,7 @@ class TestStructureChecks:
         # Add a list section
         doc.add_paragraph("SECTION 2. TEST CATEGORY DESCRIPTIONS.", style="Heading 1")
         for i in range(25):
-            doc.add_paragraph(f"• Test category {i+1}")
+            doc.add_paragraph(f"• Test category {i + 1}")
 
         # Add another regular section
         doc.add_paragraph("SECTION 3. BACKGROUND.", style="Heading 1")
@@ -295,7 +295,7 @@ class TestStructureChecks:
         for _ in range(2):
             doc.add_paragraph("Regular paragraph content")
         for i in range(20):
-            doc.add_paragraph(f"• List item {i+1}")
+            doc.add_paragraph(f"• List item {i + 1}")
 
         results = DocumentCheckResult(success=True, issues=[])
         self.structure_checks._check_section_balance([p.text for p in doc.paragraphs], results)
@@ -309,7 +309,7 @@ class TestStructureChecks:
         # Add a section with a list pattern in title
         doc.add_paragraph("SECTION 1. SHOULD INCLUDE THE FOLLOWING ITEMS.", style="Heading 1")
         for i in range(30):
-            doc.add_paragraph(f"• Item {i+1}")
+            doc.add_paragraph(f"• Item {i + 1}")
 
         # Add a regular section
         doc.add_paragraph("SECTION 2. BACKGROUND.", style="Heading 1")

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -316,6 +316,6 @@ class TestTextUtils:
         assert len(valid_words) > 0
 
     def test_calculate_passive_voice_percentage(self):
-        text = "The process was completed by the team. " "The team completed the process."
+        text = "The process was completed by the team. The team completed the process."
         pct = calculate_passive_voice_percentage(text)
         assert pct == 50.0


### PR DESCRIPTION
## Summary
- update README coverage examples to use `govdocverify`
- sync AGENTS instructions
- format code with Ruff and Black

## Testing
- `ruff check src tests`
- `ruff format src tests`
- `mypy --strict src tests`
- `bandit -r src -lll --skip B101` *(fails: command not found)*
- `semgrep --config p/ci` *(fails: command not found)*
- `pytest -q --cov=govdocverify --cov-branch --cov-fail-under=70` *(fails: no pytest-cov)*
- `pytest -q -m property` *(fails: missing deps)*
- `pytest -q -m e2e` *(fails: missing deps)*


------
https://chatgpt.com/codex/tasks/task_e_688bc7d17e0883328df9d0001edf97c1