### PR TITLE
Fix utils import

### DIFF
--- a/govdocverify/utils/__init__.py
+++ b/govdocverify/utils/__init__.py
@@ -3,4 +3,9 @@
 # Delay heavy imports (such as ``python-docx``) until needed to make test
 # collection lighter when optional dependencies are absent.
 
-__all__ = []
+# Re-export commonly used helpers for convenient access. This keeps optional
+# dependencies from being imported during test collection while allowing modules
+# to ``from govdocverify.utils import extract_docx_metadata``.
+from .metadata_utils import extract_docx_metadata
+
+__all__ = ["extract_docx_metadata"]

--- a/src/govdocverify/utils/__init__.py
+++ b/src/govdocverify/utils/__init__.py
@@ -3,4 +3,8 @@
 # Delay heavy imports (such as ``python-docx``) until needed to make test
 # collection lighter when optional dependencies are absent.
 
-__all__ = []
+# Re-export commonly used helpers for convenient access. This avoids importing
+# heavy dependencies during test discovery while keeping a stable public API.
+from .metadata_utils import extract_docx_metadata
+
+__all__ = ["extract_docx_metadata"]


### PR DESCRIPTION
## Summary
- export `extract_docx_metadata` from utils init so CLI and tests can import it

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src tests`
- `bandit -r src -lll --skip B101` *(fails: bandit not installed)*
- `semgrep --config p/ci` *(fails: semgrep not installed)*
- `pytest -q` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688bcb826e60833293f0da84b456cddf