### PR TITLE
Fix import for extract_docx_metadata

### DIFF
--- a/govdocverify/utils/__init__.py
+++ b/govdocverify/utils/__init__.py
@@ -1,6 +1,22 @@
-"""GovDocVerify utilities package."""
+"""Utility helpers for :mod:`govdocverify`.
 
-# Delay heavy imports (such as ``python-docx``) until needed to make test
-# collection lighter when optional dependencies are absent.
+This module lazily exposes selected utilities to keep import costs minimal.
+"""
 
-__all__ = []
+from __future__ import annotations
+
+from typing import Any
+
+# Delay heavy imports (such as ``python-docx``) until explicitly requested
+# to keep test collection lightweight when optional dependencies are absent.
+
+__all__ = ["extract_docx_metadata"]
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - thin wrapper
+    """Lazily import utilities on first access."""
+    if name == "extract_docx_metadata":
+        from .metadata_utils import extract_docx_metadata as func
+
+        return func
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/govdocverify/utils/__init__.py
+++ b/src/govdocverify/utils/__init__.py
@@ -1,6 +1,22 @@
-"""GovDocVerify utilities package."""
+"""Utility helpers for :mod:`govdocverify`.
 
-# Delay heavy imports (such as ``python-docx``) until needed to make test
-# collection lighter when optional dependencies are absent.
+This module lazily exposes selected utilities to keep import costs minimal.
+"""
 
-__all__ = []
+from __future__ import annotations
+
+from typing import Any
+
+# Delay heavy imports (such as ``python-docx``) until explicitly requested
+# to keep test collection lightweight when optional dependencies are absent.
+
+__all__ = ["extract_docx_metadata"]
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - thin wrapper
+    """Lazily import utilities on first access."""
+    if name == "extract_docx_metadata":
+        from .metadata_utils import extract_docx_metadata as func
+
+        return func
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary
- expose `extract_docx_metadata` from govdocverify.utils with lazy import logic

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src tests`
- `bandit -r src -lll --skip B101` *(fails: command not found)*
- `semgrep --config p/ci` *(fails: command not found)*
- `pytest -q --cov=govdocverify --cov-branch --cov-fail-under=70` *(fails: plugin missing)*

------
https://chatgpt.com/codex/tasks/task_e_688bcc7717c483328cddce7f5bae9049