### PR TITLE
docs: add security policy and scan log

### DIFF
--- a/.dev/BANDIT.md
+++ b/.dev/BANDIT.md
@@ -1,0 +1,11 @@
+# Bandit Security Scan
+
+*Date:* 2025-08-07
+
+## Command
+```bash
+bandit -r src -f json -o bandit-output.json
+```
+
+## Result
+Bandit is not installed. Attempted installation with `pip install bandit` failed due to proxy 403 errors, so the scan could not run.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+We aim to keep the project free of high or critical vulnerabilities.
+
+## Automated Scans
+We regularly run the following tools:
+
+- `bandit -r src`
+- `pip-audit -r requirements.txt`
+- `dependency-check --scan .`
+
+### 2025-08-07
+Attempts to run these scans failed because the required packages could not be installed. Each install tried to reach the upstream registries but returned **403 Forbidden** errors, so no vulnerability report was generated.
+
+## Next Steps
+Ensure network access is available so that these security tools can be installed. Once the environment is fixed, rerun the scans and address any high or critical CVEs immediately.


### PR DESCRIPTION
## Summary
- document security scanning approach and current failure due to missing tooling
- log unsuccessful Bandit run

## Testing
- `pip install bandit pip-audit --quiet` *(failed: 403 Forbidden)*
- `bandit -r src -f json -o bandit-output.json` *(command not found)*
- `pip-audit -r requirements.txt -f json -o pip-audit.json` *(command not found)*
- `dependency-check --scan . --format JSON --out dependency-check-report` *(command not found)*
- `npm install -g dependency-check` *(failed: 403 Forbidden)*
- `pytest -q` *(failed: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6894ac8fc278833292ad335f3976f810