### PR TITLE
feat: improve result cache handling

### DIFF
--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -203,6 +203,7 @@ def test_download_from_disk(monkeypatch):
     # Simulate another worker by clearing in-memory cache.
     from backend import api as bapi
 
-    bapi._RESULTS.clear()
+    with bapi._RESULTS_LOCK:
+        bapi._RESULTS.clear()
     resp2 = client.get(f"/results/{result_id}.pdf")
     assert resp2.status_code == 200

--- a/tests/test_result_cache.py
+++ b/tests/test_result_cache.py
@@ -1,0 +1,18 @@
+import importlib
+import time
+
+import pytest
+
+
+def test_result_expiration(monkeypatch, tmp_path):
+    pytest.importorskip("fastapi")
+    monkeypatch.setenv("RESULT_TTL", "1")
+    monkeypatch.setenv("RESULT_CLEANUP_INTERVAL", "0")
+    import backend.api as api
+    importlib.reload(api)
+    api._RESULTS_DIR = tmp_path
+    api._save_result("rid", {"value": 1})
+    assert api._load_result("rid") == {"value": 1}
+    time.sleep(1.2)
+    api._cleanup_results(force=True)
+    assert api._load_result("rid") is None


### PR DESCRIPTION
## Summary
- optimize result cleanup to avoid directory scan on every request and add TTL config
- protect in-memory result cache with a lock for thread safety
- test cache expiration behavior

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi>=0.109.1)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'hypothesis')*
- `coverage run -m pytest -q` *(fails: command not found: coverage)*
- `pip install coverage` *(fails: No matching distribution found for coverage)*

------
https://chatgpt.com/codex/tasks/task_e_6894cabd4750833281f71f365bae6cab