### PR TITLE
test: register pytest markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,10 @@ shell    = ["os.system", "subprocess.Popen"]
 [tool.pytest.ini_options]
 testpaths     = ["tests"]
 python_files  = "test_*.py"
+markers       = [
+  "property: property-based tests",
+  "e2e: end-to-end tests",
+]
 
 # ── Dead-code detection (vulture) ─────────────────────────────────────────────
 [tool.vulture]

--- a/tests/test_result_cache.py
+++ b/tests/test_result_cache.py
@@ -9,6 +9,7 @@ def test_result_expiration(monkeypatch, tmp_path):
     monkeypatch.setenv("RESULT_TTL", "1")
     monkeypatch.setenv("RESULT_CLEANUP_INTERVAL", "0")
     import backend.api as api
+
     importlib.reload(api)
     api._RESULTS_DIR = tmp_path
     api._save_result("rid", {"value": 1})


### PR DESCRIPTION
## Summary
- register `property` and `e2e` pytest markers in project config
- format result cache test with Black

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict tests/test_result_cache.py`
- `pytest -q`
- `pytest -q -m property`
- `pytest -q -m e2e` *(deselected: 427)*
- `bandit -r src -lll --skip B101` *(command not found)*
- `semgrep --config p/ci` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c4f2a5ac8332a82d9a0354f936ea