### PR TITLE
chore: expand pre-commit hooks and document usage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,25 @@ repos:
           ]
         additional_dependencies: ["bandit[toml]"]  # enables TOML parsing :contentReference[oaicite:0]{index=0}
 
+  # ── Semgrep: lightweight SAST ──────────────────────────────────────────────
+  - repo: https://github.com/returntocorp/semgrep
+    rev: v1.81.0
+    hooks:
+      - id: semgrep
+        args: ["--config", "p/ci"]
+
+  # ── Markdown & spelling checks ─────────────────────────────────────────────
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.17
+    hooks:
+      - id: mdformat
+        additional_dependencies: [mdformat-ruff, mdformat-gfm]
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.6
+    hooks:
+      - id: codespell
+
   - repo: https://github.com/trailofbits/pip-audit
     rev: v2.7.2
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,18 +2,29 @@
 
 Thank you for your interest in contributing to the GovDocVerify Sandbox! This guide will help you get started with the development process.
 
-## Code Formatting
+## Code Formatting and Pre-commit
 
-We use [Black](https://black.readthedocs.io/) for code formatting.
-A pre-commit hook is set up to automatically format code before each commit.
+We use [Black](https://black.readthedocs.io/) for code formatting and
+[pre-commit](https://pre-commit.com/) to run formatting, linting, and security
+checks before each commit.
 
 **Setup:**
-1. Install pre-commit:
-   `pip install pre-commit`
-2. Install the hooks:
-   `pre-commit install`
 
-This ensures your code is formatted with Black before every commit.
+1. Install pre-commit:
+   ```bash
+   pip install pre-commit
+   ```
+2. Install the git hooks:
+   ```bash
+   pre-commit install
+   ```
+3. Run all checks (optional but recommended before committing):
+   ```bash
+   pre-commit run --all-files
+   ```
+
+Pre-commit will now run automatically on `git commit` and block the commit if
+any check fails. Re-run the commit after fixing the reported issues.
 
 ## Development Setup
 

--- a/tests/test_dev_environment.py
+++ b/tests/test_dev_environment.py
@@ -1,12 +1,39 @@
 """Placeholder tests for developer environment and tooling."""
 
+import subprocess
+from pathlib import Path
+
 import pytest
 
 
-@pytest.mark.skip("DEV-01: pre-commit enforcement not implemented")
-def test_pre_commit_enforced() -> None:
+def test_pre_commit_enforced(tmp_path: Path) -> None:
     """DEV-01: pre-commit hooks run before commits."""
-    ...
+    repo = tmp_path
+
+    (repo / ".pre-commit-config.yaml").write_text(
+        """
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+"""
+    )
+
+    # Create a file with trailing whitespace to trigger the hook
+    (repo / "bad.txt").write_text("oops! \n")
+
+    subprocess.run(["git", "init"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["pre-commit", "install"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "bad.txt"], cwd=repo, check=True)
+    result = subprocess.run(
+        ["git", "commit", "-m", "test"], cwd=repo, capture_output=True, text=True
+    )
+
+    assert result.returncode != 0
+    assert "trailing-whitespace" in result.stdout
 
 
 @pytest.mark.skip("DEV-02: environment setup script not implemented")


### PR DESCRIPTION
## Summary
- add semgrep, mdformat, and codespell to pre-commit configuration
- document installing and running pre-commit hooks
- test that pre-commit blocks commits with failing checks

## Testing
- `pre-commit run --files .pre-commit-config.yaml CONTRIBUTING.md tests/test_dev_environment.py` *(failed: command not found)*
- `pip install pre-commit` *(failed: Cannot connect to proxy)*
- `pytest tests/test_dev_environment.py::test_pre_commit_enforced -q` *(failed: No such file or directory: 'pre-commit')*

------
https://chatgpt.com/codex/tasks/task_e_68a0ef7dd38c8332b07574471d2db77e