### PR TITLE
chore/dev: add lint-staged integration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,11 @@ repos:
   # ── Local test runner ───────────────────────────────────────────────────────
   - repo: local
     hooks:
+      - id: lint-staged
+        name: lint-staged
+        entry: python scripts/lint_staged.py
+        language: system
+        pass_filenames: false
       - id: pytest
         name: pytest
         entry: pytest

--- a/package.json
+++ b/package.json
@@ -8,5 +8,8 @@
   },
   "devDependencies": {
     "@types/axios": "^0.9.36"
+  },
+  "lint-staged": {
+    "*": "echo"
   }
 }

--- a/scripts/lint_staged.py
+++ b/scripts/lint_staged.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Minimal lint-staged runner for environments without Node.
+
+Reads `lint-staged` config from `package.json` and applies commands to
+staged files matching the configured globs.
+"""
+from __future__ import annotations
+
+import fnmatch
+import json
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    repo_root = Path.cwd()
+    pkg_file = repo_root / "package.json"
+    if not pkg_file.exists():
+        return 0
+    config = json.loads(pkg_file.read_text()).get("lint-staged", {})
+    if not config:
+        return 0
+
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--cached"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    files = result.stdout.strip().splitlines()
+
+    for pattern, command in config.items():
+        matched = [f for f in files if fnmatch.fnmatch(f, pattern)]
+        if not matched:
+            continue
+        cmd = shlex.split(command) + matched
+        res = subprocess.run(cmd, cwd=repo_root)
+        if res.returncode != 0:
+            return res.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- integrate minimal lint-staged runner with pre-commit
- configure lint-staged in package.json
- test lint-staged processes only staged files

## Testing
- `python scripts/lint_staged.py`
- `pytest tests/test_dev_environment.py::test_lint_staged_integration -q` *(fails: pre-commit not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68a0fe9a00b48332b288bd806d05c7fb