### PR TITLE
Fix CI dependency installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install uv poetry
-          poetry install --with dev
-          poetry lock --no-update
+          poetry lock
+          poetry install --extras "dev"
           uv pip sync pyproject.toml
 
       - name: Install project (editable)


### PR DESCRIPTION
## Summary
- install development dependencies via extras instead of non-existent group
- update poetry lock command for Poetry 2.x

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found: pre-commit)*
- `pytest -q` *(interrupt: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68a1022e016c833297e27b664cb9c8af