### PR TITLE
ci: run uv pip sync in system environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           pip install uv poetry
           poetry lock
           poetry install --extras "dev"
-          uv pip sync pyproject.toml
+          uv pip sync --system pyproject.toml
 
       - name: Install project (editable)
         run: pip install -e .


### PR DESCRIPTION
## Summary
- ensure `uv pip sync` targets the system env in CI

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a104cb8ab883328433e14beb54c786