### PR TITLE
Ensure pre-commit is installed in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install uv poetry
           poetry lock
-          poetry install --extras "dev"
-          uv pip sync --system pyproject.toml
+          uv pip install --system --extra dev .
 
       - name: Install project (editable)
         run: pip install -e .


### PR DESCRIPTION
## Summary
- install dev dependencies with uv so that pre-commit is available in CI

## Testing
- `pre-commit run --all-files` *(fails: command not found; network blocks package installation)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a10cf4a32483328c4850ac5db1398d