### PR TITLE
Add Makefile task runner and integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+.PHONY: format lint test
+
+format:
+	ruff format $(FORMAT_ARGS) .
+
+lint:
+	ruff check .
+
+test:
+	pytest $(PYTEST_ADDOPTS)
+

--- a/govdocverify/utils/__init__.py
+++ b/govdocverify/utils/__init__.py
@@ -7,7 +7,7 @@ while still letting callers write
 
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 __all__: list[str] = ["extract_docx_metadata"]
 

--- a/scripts/lint_staged.py
+++ b/scripts/lint_staged.py
@@ -4,13 +4,13 @@
 Reads `lint-staged` config from `package.json` and applies commands to
 staged files matching the configured globs.
 """
+
 from __future__ import annotations
 
 import fnmatch
 import json
 import shlex
 import subprocess
-import sys
 from pathlib import Path
 
 

--- a/tests/test_task_runner.py
+++ b/tests/test_task_runner.py
@@ -1,0 +1,35 @@
+"""Tests for the Makefile task runner."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_make_lint_runs_successfully() -> None:
+    result = subprocess.run(["make", "lint"], cwd=REPO_ROOT, capture_output=True, text=True)
+    assert result.returncode == 0
+
+
+def test_make_format_runs_successfully(tmp_path: Path) -> None:
+    tmp_repo = tmp_path / "repo"
+    shutil.copytree(REPO_ROOT, tmp_repo)
+    result = subprocess.run(["make", "format"], cwd=tmp_repo, capture_output=True, text=True)
+    assert result.returncode == 0
+
+
+def test_make_test_runs_subset() -> None:
+    env = os.environ.copy()
+    env["PYTEST_ADDOPTS"] = "-k test_task_runner_dummy"
+    result = subprocess.run(
+        ["make", "test"], cwd=REPO_ROOT, env=env, capture_output=True, text=True
+    )
+    assert result.returncode == 0
+
+
+def test_task_runner_dummy() -> None:
+    assert True


### PR DESCRIPTION
## Summary
- add Makefile with `lint`, `format`, and `test` targets
- implement task runner integration test and new tests for each Makefile target
- tidy imports so lint target passes

## Testing
- `make lint`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a10f5b9650833296e0bc8981a91372