### PR TITLE
ci: run lint and tests in parallel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,38 @@ on:
     branches: [ main, BugFixing ]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Cache Poetry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.cache/pip
+          key: poetry-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install uv poetry
+          poetry lock
+          uv pip install --system --extra dev .
+
+      - name: Install project (editable)
+        run: pip install -e .
+
+      - name: Run pre-commit checks
+        run: pre-commit run --all-files
+
   test:
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -39,9 +71,6 @@ jobs:
 
       - name: Install project (editable)
         run: pip install -e .
-
-      - name: Run pre-commit checks
-        run: pre-commit run --all-files
 
       - name: Run tests with coverage
         run: |


### PR DESCRIPTION
## Summary
- split CI workflow into lint and test jobs that run in parallel
- add runtime check test for parallel execution in CI scenarios

## Testing
- `ruff check tests/test_ci_scenarios.py`
- `black --check tests/test_ci_scenarios.py`
- `pytest tests/test_ci_scenarios.py::test_parallel_ci_execution -q`
- `pre-commit run --files .github/workflows/ci.yml tests/test_ci_scenarios.py` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `yamllint -v` *(fails: command not found)*
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*

------
https://chatgpt.com/codex/tasks/task_e_68a119d218f48332a0afffa8b9ccafea