### PR TITLE
feat(validation): add source restrictions

### DIFF
--- a/govdocverify/config/document_config.py
+++ b/govdocverify/config/document_config.py
@@ -10,3 +10,7 @@ READABILITY_CONFIG = {
 }
 
 # Add other document configuration settings as needed
+
+# Acceptable source domains and file extensions
+ALLOWED_SOURCE_DOMAINS = [".gov", ".mil"]
+ALLOWED_FILE_EXTENSIONS = [".docx", ".doc"]

--- a/src/govdocverify/config/document_config.py
+++ b/src/govdocverify/config/document_config.py
@@ -9,4 +9,10 @@ READABILITY_CONFIG = {
     "max_passive_voice_percentage": 10,
 }
 
+# Acceptable source domains for document validation
+ALLOWED_SOURCE_DOMAINS = [".gov", ".mil"]
+
+# Acceptable file extensions for uploaded or referenced documents
+ALLOWED_FILE_EXTENSIONS = [".docx", ".doc"]
+
 # Add other document configuration settings as needed

--- a/src/govdocverify/document_checker.py
+++ b/src/govdocverify/document_checker.py
@@ -17,11 +17,12 @@ from govdocverify.checks.reference_checks import (
 )
 from govdocverify.checks.structure_checks import StructureChecks
 from govdocverify.checks.terminology_checks import TerminologyChecks
-from govdocverify.models import DocumentCheckResult
+from govdocverify.models import DocumentCheckResult, Severity
 from govdocverify.utils.pattern_cache import PatternCache
 from govdocverify.utils.terminology_utils import TerminologyManager
 
 from .utils.check_discovery import validate_check_registration
+from .utils.security import SecurityError, validate_source
 
 
 @lru_cache(maxsize=8)
@@ -95,6 +96,9 @@ class FAADocumentChecker:
     ) -> DocumentCheckResult:
         """Run all document checks."""
         try:
+            # Validate source before processing
+            validate_source(document_path)
+
             combined_results = DocumentCheckResult()
             per_check_results = {}
 
@@ -114,7 +118,10 @@ class FAADocumentChecker:
             combined_results.success = len(combined_results.issues) == 0
             logger.info(f"Completed all checks. Found {len(combined_results.issues)} issues.")
             return combined_results
-
+        except SecurityError as e:
+            result = DocumentCheckResult(success=False)
+            result.add_issue(str(e), Severity.ERROR)
+            return result
         except Exception as e:
             logger.error(f"Error running document checks: {str(e)}")
             return DocumentCheckResult(

--- a/tests/test_non_goals_guards.py
+++ b/tests/test_non_goals_guards.py
@@ -1,15 +1,19 @@
-"""Placeholder tests for non-goals guardrails."""
+"""Tests for non-goals guardrails to ensure irrelevant docs are rejected."""
 
-import pytest
+from govdocverify.document_checker import FAADocumentChecker
 
 
-@pytest.mark.skip("NG-01: rejection of non-government docs not implemented")
 def test_rejects_non_government_docs() -> None:
     """NG-01: system should reject documents outside scope."""
-    ...
+    checker = FAADocumentChecker()
+    result = checker.run_all_document_checks("https://example.com/doc.docx")
+    assert not result.success
+    assert any("Non-government" in issue["message"] for issue in result.issues)
 
 
-@pytest.mark.skip("NG-02: exclusion of legacy formats not implemented")
 def test_excludes_legacy_formats() -> None:
     """NG-02: legacy document formats are ignored."""
-    ...
+    checker = FAADocumentChecker()
+    result = checker.run_all_document_checks("document.pdf")
+    assert not result.success
+    assert any("Disallowed file format" in issue["message"] for issue in result.issues)


### PR DESCRIPTION
## Summary
- reject documents from non-government domains and legacy formats
- configure allowed domains and extensions
- ensure non-government inputs are caught in tests

## Testing
- `ruff check govdocverify src tests`
- `ruff format govdocverify src tests`
- `black --check govdocverify src tests`
- `mypy --strict govdocverify src tests` *(fails: Duplicate module named "govdocverify")*
- `bandit -r src -lll --skip B101` *(command not found)*
- `semgrep --config p/ci` *(command not found)*
- `pytest tests/test_non_goals_guards.py -q`
- `pytest -q`
- `pytest -q -m property`
- `pytest -q -m e2e`


------
https://chatgpt.com/codex/tasks/task_e_68a11ccb211883328ae9b740a687254f