### PR TITLE
Reject legacy document formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ FAA‑style validation for Word docs—CLI, FastAPI, and React UI in one toolkit
 
 Full technical docs live under **`docs/`**; start with *docs/getting‑started.md* when you’re ready to dig deeper.
 
+## 📄 Supported document formats
+
+GovDocVerify accepts only modern `.docx` files. Legacy formats—such as `.doc`, `.pdf`, `.rtf`, and `.txt`—are rejected during validation.
+
 ---
 
 ## ✨ Quick install (recommended)

--- a/govdocverify/config/document_config.py
+++ b/govdocverify/config/document_config.py
@@ -13,4 +13,7 @@ READABILITY_CONFIG = {
 
 # Acceptable source domains and file extensions
 ALLOWED_SOURCE_DOMAINS = [".gov", ".mil"]
-ALLOWED_FILE_EXTENSIONS = [".docx", ".doc"]
+ALLOWED_FILE_EXTENSIONS = [".docx"]
+
+# File extensions that are explicitly rejected as legacy formats
+LEGACY_FILE_EXTENSIONS = [".doc", ".pdf", ".rtf", ".txt"]

--- a/govdocverify/utils/security.py
+++ b/govdocverify/utils/security.py
@@ -12,6 +12,7 @@ from fastapi import HTTPException
 from govdocverify.config.document_config import (
     ALLOWED_FILE_EXTENSIONS,
     ALLOWED_SOURCE_DOMAINS,
+    LEGACY_FILE_EXTENSIONS,
 )
 
 # Configure logging
@@ -22,7 +23,12 @@ logger = logging.getLogger(__name__)
 MAX_FILE_SIZE = 5 * 1024 * 1024  # 5MB
 ALLOWED_MIME_TYPES = {
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+}
+LEGACY_MIME_TYPES = {
     "application/msword": ".doc",
+    "application/pdf": ".pdf",
+    "text/rtf": ".rtf",
+    "text/plain": ".txt",
 }
 
 
@@ -71,6 +77,8 @@ def validate_file(file_path: str) -> None:
 
         # Check file type using filetype
         kind = filetype.guess(file_path)
+        if kind and kind.mime in LEGACY_MIME_TYPES:
+            raise SecurityError(f"Legacy file format: {LEGACY_MIME_TYPES[kind.mime]}")
         if not kind or kind.mime not in ALLOWED_MIME_TYPES:
             raise SecurityError(
                 f"Invalid file type. Allowed types: {', '.join(ALLOWED_MIME_TYPES.values())}"
@@ -146,6 +154,8 @@ def _is_allowed_domain(domain: str) -> bool:
 def validate_source(path: str) -> None:
     """Validate that ``path`` is from an approved domain and format."""
     _, ext = os.path.splitext(path.lower())
+    if ext and ext in LEGACY_FILE_EXTENSIONS:
+        raise SecurityError(f"Legacy file format: {ext}")
     if ext and ext not in ALLOWED_FILE_EXTENSIONS:
         raise SecurityError(f"Disallowed file format: {ext}")
 

--- a/src/govdocverify/config/document_config.py
+++ b/src/govdocverify/config/document_config.py
@@ -13,6 +13,9 @@ READABILITY_CONFIG = {
 ALLOWED_SOURCE_DOMAINS = [".gov", ".mil"]
 
 # Acceptable file extensions for uploaded or referenced documents
-ALLOWED_FILE_EXTENSIONS = [".docx", ".doc"]
+ALLOWED_FILE_EXTENSIONS = [".docx"]
+
+# Explicitly rejected legacy file extensions
+LEGACY_FILE_EXTENSIONS = [".doc", ".pdf", ".rtf", ".txt"]
 
 # Add other document configuration settings as needed

--- a/tests/test_non_goals_guards.py
+++ b/tests/test_non_goals_guards.py
@@ -1,5 +1,7 @@
 """Tests for non-goals guardrails to ensure irrelevant docs are rejected."""
 
+import pytest
+
 from govdocverify.document_checker import FAADocumentChecker
 
 
@@ -11,9 +13,10 @@ def test_rejects_non_government_docs() -> None:
     assert any("Non-government" in issue["message"] for issue in result.issues)
 
 
-def test_excludes_legacy_formats() -> None:
+@pytest.mark.parametrize("path", ["document.pdf", "document.doc"])
+def test_exclude_legacy_formats(path: str) -> None:
     """NG-02: legacy document formats are ignored."""
     checker = FAADocumentChecker()
-    result = checker.run_all_document_checks("document.pdf")
+    result = checker.run_all_document_checks(path)
     assert not result.success
-    assert any("Disallowed file format" in issue["message"] for issue in result.issues)
+    assert any("Legacy file format" in issue["message"] for issue in result.issues)

--- a/tests/test_security_utils.py
+++ b/tests/test_security_utils.py
@@ -2,7 +2,11 @@ from pathlib import Path
 
 import pytest
 
-from govdocverify.utils.security import SecurityError, sanitize_file_path
+from govdocverify.utils.security import (
+    SecurityError,
+    sanitize_file_path,
+    validate_source,
+)
 
 
 def test_sanitize_allows_absolute_paths(tmp_path: Path) -> None:
@@ -24,3 +28,9 @@ def test_sanitize_base_dir_enforced(tmp_path: Path) -> None:
     outside.write_text("test")
     with pytest.raises(SecurityError):
         sanitize_file_path(str(outside), base_dir=str(base))
+
+
+@pytest.mark.parametrize("path", ["file.doc", "file.pdf", "file.rtf"])
+def test_validate_source_rejects_legacy_formats(path: str) -> None:
+    with pytest.raises(SecurityError, match="Legacy file format"):
+        validate_source(path)


### PR DESCRIPTION
## Summary
- document supported `.docx` format and note legacy types
- reject legacy extensions (`.doc`, `.pdf`, `.rtf`, `.txt`) in validation
- add tests covering legacy format errors

## Testing
- `pytest tests/test_non_goals_guards.py::test_exclude_legacy_formats -q`
- `pytest tests/test_security_utils.py -q`
- `pre-commit run --files README.md govdocverify/config/document_config.py govdocverify/utils/security.py src/govdocverify/config/document_config.py src/govdocverify/utils/security.py tests/test_non_goals_guards.py tests/test_security_utils.py` *(failed: command not found)*
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68a122bb858c8332889ad7d3d1c75838