### PR TITLE
feat: add retry for HTTP requests

### DIFF
--- a/govdocverify/utils/decorators.py
+++ b/govdocverify/utils/decorators.py
@@ -1,7 +1,10 @@
 import logging
+import os
 import time
 from functools import wraps
 from typing import Any, Callable, TypeVar, cast
+
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
 
@@ -22,3 +25,27 @@ def profile_performance(func: F) -> F:
         return result
 
     return cast(F, wrapper)
+
+
+def retry_transient(max_attempts: int | None = None, backoff: float | None = None) -> Callable[[F], F]:
+    """Retry decorated function on transient errors with exponential backoff.
+
+    Defaults are configured via ``GOVDOCVERIFY_MAX_RETRIES`` and
+    ``GOVDOCVERIFY_BACKOFF`` environment variables.
+    """
+
+    max_attempts = max_attempts or int(os.getenv("GOVDOCVERIFY_MAX_RETRIES", "3"))
+    backoff = backoff or float(os.getenv("GOVDOCVERIFY_BACKOFF", "0.1"))
+
+    def decorator(func: F) -> F:
+        return cast(
+            F,
+            retry(
+                retry=retry_if_exception_type(Exception),
+                stop=stop_after_attempt(max_attempts),
+                wait=wait_exponential(multiplier=backoff),
+                reraise=True,
+            )(func),
+        )
+
+    return decorator

--- a/govdocverify/utils/network.py
+++ b/govdocverify/utils/network.py
@@ -1,0 +1,21 @@
+"""HTTP helpers with retry support."""
+
+from __future__ import annotations
+
+import httpx
+
+from govdocverify.utils.decorators import retry_transient
+
+
+@retry_transient()
+def fetch_url(url: str) -> str:
+    """Return the text content from ``url``.
+
+    Requests are retried on transient failures according to configuration
+    provided via environment variables.
+    """
+
+    response = httpx.get(url)
+    response.raise_for_status()
+    return response.text
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
   "zipp==3.19.1",
   "anyio>=4.4.0",
   "httpx>=0.27,<0.28",
+  "tenacity>=8.2,<9.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ hypothesis>=6.0
 # Optional: Only needed if running the FastAPI backend directly
 uvicorn>=0.23.0
 httpx>=0.28.1
+tenacity>=8.2,<9.0

--- a/src/govdocverify/utils/decorators.py
+++ b/src/govdocverify/utils/decorators.py
@@ -1,7 +1,10 @@
 import logging
+import os
 import time
 from functools import wraps
 from typing import Any, Callable, TypeVar, cast
+
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 logger = logging.getLogger(__name__)
 
@@ -22,3 +25,27 @@ def profile_performance(func: F) -> F:
         return result
 
     return cast(F, wrapper)
+
+
+def retry_transient(max_attempts: int | None = None, backoff: float | None = None) -> Callable[[F], F]:
+    """Retry decorated function on transient errors with exponential backoff.
+
+    Defaults are configured via ``GOVDOCVERIFY_MAX_RETRIES`` and
+    ``GOVDOCVERIFY_BACKOFF`` environment variables.
+    """
+
+    max_attempts = max_attempts or int(os.getenv("GOVDOCVERIFY_MAX_RETRIES", "3"))
+    backoff = backoff or float(os.getenv("GOVDOCVERIFY_BACKOFF", "0.1"))
+
+    def decorator(func: F) -> F:
+        return cast(
+            F,
+            retry(
+                retry=retry_if_exception_type(Exception),
+                stop=stop_after_attempt(max_attempts),
+                wait=wait_exponential(multiplier=backoff),
+                reraise=True,
+            )(func),
+        )
+
+    return decorator

--- a/src/govdocverify/utils/network.py
+++ b/src/govdocverify/utils/network.py
@@ -1,0 +1,21 @@
+"""HTTP helpers with retry support."""
+
+from __future__ import annotations
+
+import httpx
+
+from govdocverify.utils.decorators import retry_transient
+
+
+@retry_transient()
+def fetch_url(url: str) -> str:
+    """Return the text content from ``url``.
+
+    Requests are retried on transient failures according to configuration
+    provided via environment variables.
+    """
+
+    response = httpx.get(url)
+    response.raise_for_status()
+    return response.text
+

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -1,12 +1,26 @@
-"""Placeholder tests for reliability and error resilience."""
+"""Tests for reliability and error resilience."""
 
+import httpx
 import pytest
 
+from govdocverify.utils.network import fetch_url
 
-@pytest.mark.skip("RE-01: retry logic for transient failures not implemented")
-def test_transient_retry_logic() -> None:
-    """RE-01: operations should be retried on transient errors."""
-    ...
+
+def test_retry_transient_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RE-01: operations are retried on transient errors before failing."""
+
+    attempts = {"count": 0}
+
+    def flaky_get(url: str) -> httpx.Response:
+        attempts["count"] += 1
+        raise httpx.RequestError("boom", request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(httpx, "get", flaky_get)
+
+    with pytest.raises(httpx.RequestError):
+        fetch_url("https://example.com")
+
+    assert attempts["count"] == 3
 
 
 @pytest.mark.skip("RE-02: partial failure reporting not implemented")

--- a/valid_words.txt
+++ b/valid_words.txt
@@ -1429,6 +1429,7 @@ background
 BACKGROUND
 backhand
 backing
+backoff
 backpack
 backpacking
 backpacks


### PR DESCRIPTION
## Summary
- add tenacity-based retry decorator
- retry HTTP fetches with exponential backoff
- test transient failure retries

## Testing
- `pre-commit run --files govdocverify/utils/decorators.py src/govdocverify/utils/decorators.py govdocverify/utils/network.py src/govdocverify/utils/network.py tests/test_reliability.py pyproject.toml requirements.txt valid_words.txt` *(fails: command not found)*
- `pip install pre-commit` *(fails: No matching distribution found for pre-commit)*
- `pip install tenacity` *(fails: No matching distribution found for tenacity)*
- `pytest tests/test_reliability.py::test_retry_transient_failures` *(fails: ModuleNotFoundError: No module named 'tenacity')*

------
https://chatgpt.com/codex/tasks/task_e_68a1249a90348332ac45c56e91f500da