### PR TITLE
feat: report partial failures during document checks

### DIFF
--- a/govdocverify/document_checker.py
+++ b/govdocverify/document_checker.py
@@ -115,7 +115,9 @@ class FAADocumentChecker:
             self._populate_check_results(combined_results, per_check_results)
 
             combined_results.per_check_results = per_check_results
-            combined_results.success = len(combined_results.issues) == 0
+            combined_results.success = (
+                len(combined_results.issues) == 0 and not combined_results.partial_failures
+            )
             logger.info(f"Completed all checks. Found {len(combined_results.issues)} issues.")
             return combined_results
 
@@ -205,9 +207,10 @@ class FAADocumentChecker:
                 issues=[{"error": f"Error in {category} checks: {str(error)}"}],
             )
             per_check_results[category][check_func] = dcr
-        combined_results.issues.append(
+        combined_results.partial_failures.append(
             {"error": f"Error in {category} checks: {str(error)}", "category": category}
         )
+        combined_results.success = False
 
     def _populate_check_results(
         self,

--- a/govdocverify/models.py
+++ b/govdocverify/models.py
@@ -66,11 +66,14 @@ class DocumentCheckResult:
     score: float = 1.0
     severity: Optional["Severity"] = None
     details: Optional[Dict[str, Any]] = None
+    partial_failures: List[Dict[str, Any]] | None = None
 
     def __post_init__(self):
         """Initialize default values."""
         if self.issues is None:
             self.issues = []
+        if self.partial_failures is None:
+            self.partial_failures = []
         self.severity = None  # Will be set on first issue
 
     def add_issue(

--- a/govdocverify/models/__init__.py
+++ b/govdocverify/models/__init__.py
@@ -101,6 +101,7 @@ class DocumentCheckResult:
     score: float = 1.0
     severity: Optional["Severity"] = None
     details: Optional[Dict[str, Any]] = None
+    partial_failures: List[Dict[str, Any]] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         """Initialize default values and ensure all issues have a category."""

--- a/govdocverify/processing.py
+++ b/govdocverify/processing.py
@@ -51,9 +51,9 @@ def _check_results_have_issues(results_dict: Dict[str, Dict[str, Any]]) -> bool:
     return False
 
 
-def _create_fallback_results_dict(results: DocumentCheckResult) -> Dict[str, Dict[str, Any]]:
+def _create_fallback_results_dict(results: DocumentCheckResult) -> Dict[str, Any]:
     """Create fallback results dictionary when per_check_results is unavailable."""
-    return {
+    fallback = {
         "all": {
             "all": {
                 "success": results.success,
@@ -62,9 +62,12 @@ def _create_fallback_results_dict(results: DocumentCheckResult) -> Dict[str, Dic
             }
         }
     }
+    if results.partial_failures:
+        fallback["partial_failures"] = results.partial_failures
+    return fallback
 
 
-def build_results_dict(results: DocumentCheckResult) -> Dict[str, Dict[str, Any]]:
+def build_results_dict(results: DocumentCheckResult) -> Dict[str, Any]:
     """Return a normalized results dictionary from a check result."""
     results_dict = getattr(results, "per_check_results", None)
     logger.debug("[DIAG] per_check_results present: %s", results_dict is not None)
@@ -90,5 +93,8 @@ def build_results_dict(results: DocumentCheckResult) -> Dict[str, Dict[str, Any]
         )
         logger.debug("[DIAG] per_check_results content: %s", results_dict)
         return _create_fallback_results_dict(results)
+
+    if results.partial_failures:
+        results_dict["partial_failures"] = results.partial_failures
 
     return results_dict

--- a/govdocverify/utils/decorators.py
+++ b/govdocverify/utils/decorators.py
@@ -27,7 +27,9 @@ def profile_performance(func: F) -> F:
     return cast(F, wrapper)
 
 
-def retry_transient(max_attempts: int | None = None, backoff: float | None = None) -> Callable[[F], F]:
+def retry_transient(
+    max_attempts: int | None = None, backoff: float | None = None
+) -> Callable[[F], F]:
     """Retry decorated function on transient errors with exponential backoff.
 
     Defaults are configured via ``GOVDOCVERIFY_MAX_RETRIES`` and

--- a/govdocverify/utils/network.py
+++ b/govdocverify/utils/network.py
@@ -18,4 +18,3 @@ def fetch_url(url: str) -> str:
     response = httpx.get(url)
     response.raise_for_status()
     return response.text
-

--- a/src/govdocverify/document_checker.py
+++ b/src/govdocverify/document_checker.py
@@ -115,7 +115,9 @@ class FAADocumentChecker:
             self._populate_check_results(combined_results, per_check_results)
 
             combined_results.per_check_results = per_check_results
-            combined_results.success = len(combined_results.issues) == 0
+            combined_results.success = (
+                len(combined_results.issues) == 0 and not combined_results.partial_failures
+            )
             logger.info(f"Completed all checks. Found {len(combined_results.issues)} issues.")
             return combined_results
         except SecurityError as e:
@@ -204,9 +206,10 @@ class FAADocumentChecker:
                 issues=[{"error": f"Error in {category} checks: {str(error)}"}],
             )
             per_check_results[category][check_func] = dcr
-        combined_results.issues.append(
+        combined_results.partial_failures.append(
             {"error": f"Error in {category} checks: {str(error)}", "category": category}
         )
+        combined_results.success = False
 
     def _populate_check_results(
         self,

--- a/src/govdocverify/models.py
+++ b/src/govdocverify/models.py
@@ -66,11 +66,14 @@ class DocumentCheckResult:
     score: float = 1.0
     severity: Optional["Severity"] = None
     details: Optional[Dict[str, Any]] = None
+    partial_failures: List[Dict[str, Any]] | None = None
 
     def __post_init__(self):
         """Initialize default values."""
         if self.issues is None:
             self.issues = []
+        if self.partial_failures is None:
+            self.partial_failures = []
         self.severity = None  # Will be set on first issue
 
     def add_issue(

--- a/src/govdocverify/models/__init__.py
+++ b/src/govdocverify/models/__init__.py
@@ -101,6 +101,7 @@ class DocumentCheckResult:
     score: float = 1.0
     severity: Optional["Severity"] = None
     details: Optional[Dict[str, Any]] = None
+    partial_failures: List[Dict[str, Any]] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         """Initialize default values and ensure all issues have a category."""

--- a/src/govdocverify/processing.py
+++ b/src/govdocverify/processing.py
@@ -51,9 +51,9 @@ def _check_results_have_issues(results_dict: Dict[str, Dict[str, Any]]) -> bool:
     return False
 
 
-def _create_fallback_results_dict(results: DocumentCheckResult) -> Dict[str, Dict[str, Any]]:
+def _create_fallback_results_dict(results: DocumentCheckResult) -> Dict[str, Any]:
     """Create fallback results dictionary when per_check_results is unavailable."""
-    return {
+    fallback = {
         "all": {
             "all": {
                 "success": results.success,
@@ -62,9 +62,12 @@ def _create_fallback_results_dict(results: DocumentCheckResult) -> Dict[str, Dic
             }
         }
     }
+    if results.partial_failures:
+        fallback["partial_failures"] = results.partial_failures
+    return fallback
 
 
-def build_results_dict(results: DocumentCheckResult) -> Dict[str, Dict[str, Any]]:
+def build_results_dict(results: DocumentCheckResult) -> Dict[str, Any]:
     """Return a normalized results dictionary from a check result."""
     results_dict = getattr(results, "per_check_results", None)
     logger.debug("[DIAG] per_check_results present: %s", results_dict is not None)
@@ -90,5 +93,8 @@ def build_results_dict(results: DocumentCheckResult) -> Dict[str, Dict[str, Any]
         )
         logger.debug("[DIAG] per_check_results content: %s", results_dict)
         return _create_fallback_results_dict(results)
+
+    if results.partial_failures:
+        results_dict["partial_failures"] = results.partial_failures
 
     return results_dict

--- a/src/govdocverify/utils/decorators.py
+++ b/src/govdocverify/utils/decorators.py
@@ -27,7 +27,9 @@ def profile_performance(func: F) -> F:
     return cast(F, wrapper)
 
 
-def retry_transient(max_attempts: int | None = None, backoff: float | None = None) -> Callable[[F], F]:
+def retry_transient(
+    max_attempts: int | None = None, backoff: float | None = None
+) -> Callable[[F], F]:
     """Retry decorated function on transient errors with exponential backoff.
 
     Defaults are configured via ``GOVDOCVERIFY_MAX_RETRIES`` and

--- a/src/govdocverify/utils/network.py
+++ b/src/govdocverify/utils/network.py
@@ -18,4 +18,3 @@ def fetch_url(url: str) -> str:
     response = httpx.get(url)
     response.raise_for_status()
     return response.text
-

--- a/tests/test_backend_api.py
+++ b/tests/test_backend_api.py
@@ -33,7 +33,9 @@ def test_rate_limiting(monkeypatch):
         ) as rl,
         mock.patch("govdocverify.utils.security.filetype.guess") as guess,
     ):
-        guess.return_value = mock.Mock(mime="application/msword")
+        guess.return_value = mock.Mock(
+            mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        )
         rl.requests.clear()
         resp1 = client.post(
             "/process",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,7 @@ class TestCLI:
             {
                 "success": True,
                 "issues": [],
+                "partial_failures": [],
                 "per_check_results": {
                     "test_category": {"test_check": {"success": True, "issues": [], "details": {}}}
                 },

--- a/tests/test_new_coverage.py
+++ b/tests/test_new_coverage.py
@@ -36,7 +36,9 @@ def test_validate_file_and_rate_limiter(tmp_path):
     f = tmp_path / "x.docx"
     f.write_bytes(b"test")
     with mock.patch("govdocverify.utils.security.filetype.guess") as g:
-        g.return_value = mock.Mock(mime="application/msword")
+        g.return_value = mock.Mock(
+            mime="application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        )
         validate_file(str(f))
         g.return_value = None
         with pytest.raises(SecurityError):

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -3,6 +3,8 @@
 import httpx
 import pytest
 
+from govdocverify.document_checker import FAADocumentChecker
+from govdocverify.processing import build_results_dict
 from govdocverify.utils.network import fetch_url
 
 
@@ -23,10 +25,27 @@ def test_retry_transient_failures(monkeypatch: pytest.MonkeyPatch) -> None:
     assert attempts["count"] == 3
 
 
-@pytest.mark.skip("RE-02: partial failure reporting not implemented")
-def test_partial_failure_reporting() -> None:
+def test_partial_failure_reporting(monkeypatch: pytest.MonkeyPatch) -> None:
     """RE-02: partial failures should surface detailed reports."""
-    ...
+
+    checker = FAADocumentChecker()
+
+    def boom(doc: object, doc_type: str | None) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        checker,
+        "_get_check_modules",
+        lambda: [(checker.readability_checks, "readability")],
+    )
+    monkeypatch.setattr(checker.readability_checks, "check_document", boom)
+
+    result = checker.run_all_document_checks("content")
+    assert result.partial_failures and result.partial_failures[0]["category"] == "readability"
+    assert "boom" in result.partial_failures[0]["error"]
+
+    out = build_results_dict(result)
+    assert out["partial_failures"][0]["category"] == "readability"
 
 
 @pytest.mark.skip("RE-03: graceful shutdown under load not implemented")


### PR DESCRIPTION
## Summary
- track partial failures in document check results
- surface partial errors in processing output
- add reliability test ensuring partial failures are reported

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src tests`
- `bandit -r src -lll --skip B101` *(fails: command not found)*
- `semgrep --config p/ci` *(fails: command not found)*
- `pytest -q --cov=govdocverify --cov-branch --cov-fail-under=70` *(fails: plugin missing)*
- `pytest -q`
- `pytest -q -m property` *(fails: DeadlineExceeded)*
- `pytest -q -m e2e`


------
https://chatgpt.com/codex/tasks/task_e_68a1276931b883328013988328025f01