### PR TITLE
Add download links and backend integration

### DIFF
--- a/frontend/govdocverify/src/components/DownloadButtons.tsx
+++ b/frontend/govdocverify/src/components/DownloadButtons.tsx
@@ -2,19 +2,23 @@ interface Props {
   resultId: string;
 }
 
+const API_BASE = import.meta.env.VITE_API_BASE || "http://127.0.0.1:8000";
+
 export default function DownloadButtons({ resultId }: Props) {
-  const base = `/api/results/${resultId}`;
+  const base = `${API_BASE}/results/${resultId}`;
   return (
     <div className="mt-4 space-x-2">
       <a
         href={`${base}.docx`}
         className="bg-green-600 text-white px-3 py-1 rounded"
+        download
       >
         Download DOCX
       </a>
       <a
         href={`${base}.pdf`}
         className="bg-green-600 text-white px-3 py-1 rounded"
+        download
       >
         Download PDF
       </a>


### PR DESCRIPTION
## Summary
- add environment-aware download buttons for DOCX and PDF results
- verify downloadable files via new frontend tests

## Testing
- `pytest tests/test_frontend_placeholder.py::test_download_actions tests/test_backend_api.py::test_download_results tests/test_backend_api.py::test_download_missing_result tests/test_backend_api.py::test_download_unsupported_format tests/test_backend_api.py::test_download_from_disk -q`
- `pre-commit run --files frontend/govdocverify/src/components/DownloadButtons.tsx tests/test_frontend_placeholder.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1bd0dd7848332893f698a7919de00