### PR TITLE
feat/api: define public package surface

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -17,5 +17,31 @@ Uploads a document and returns check results.
   "has_errors": true,
   "rendered": "<html>...",
   "by_category": {"format": []}
-}
+  }
+  ```
+
+## Python Package API
+
+In addition to the HTTP endpoint, ``govdocverify`` ships a lightweight Python
+API for embedding document checks into your own tools.
+
+```python
+from govdocverify import DocumentChecker, save_results_as_docx
+
+checker = DocumentChecker()
+results = checker.run_all_document_checks("example.docx")
+if not results.success:
+    save_results_as_docx(results.__dict__, "report.docx")
 ```
+
+### Exported symbols
+
+* ``DocumentChecker`` – orchestrates the standard suite of checks.
+* ``DocumentCheckResult`` – container describing the outcome of a run.
+* ``VisibilitySettings`` – toggles groups of checks in rendered output.
+* ``Severity`` – enum representing the severity of an issue.
+* ``save_results_as_docx`` / ``save_results_as_pdf`` – helpers for persisting
+  results.
+
+Everything else in the repository is considered **internal** and may change
+without notice.

--- a/govdocverify/__init__.py
+++ b/govdocverify/__init__.py
@@ -1,5 +1,30 @@
-"""GovDocVerify package."""
+"""Top-level package for the GovDocVerify Python API.
 
-# Avoid importing the CLI at module import time so that unit tests can run
+The module exposes a **very** small and well defined public surface.  Everything
+else in the repository should be considered internal and may change without
+notice.  The exported names are re-imported here for convenience and documented
+in :ref:`docs/api-reference.md`.
+
+Example
+-------
+>>> from govdocverify import DocumentChecker
+>>> checker = DocumentChecker()
+>>> result = checker.run_all_document_checks("path/to.docx")
+>>> result.success
+True
+"""
+
+# Only import lightweight items at module import time so that unit tests can run
 # without pulling in heavy optional dependencies (e.g. ``docx`` or ``uvicorn``).
-__all__ = []
+from .document_checker import FAADocumentChecker as DocumentChecker
+from .export import save_results_as_docx, save_results_as_pdf
+from .models import DocumentCheckResult, Severity, VisibilitySettings
+
+__all__ = [
+    "DocumentChecker",
+    "DocumentCheckResult",
+    "VisibilitySettings",
+    "Severity",
+    "save_results_as_docx",
+    "save_results_as_pdf",
+]

--- a/src/govdocverify/__init__.py
+++ b/src/govdocverify/__init__.py
@@ -1,5 +1,29 @@
-"""GovDocVerify package."""
+"""Top-level package for the GovDocVerify Python API.
 
-# Avoid importing the CLI at module import time so that unit tests can run
-# without pulling in heavy optional dependencies (e.g. ``docx`` or ``uvicorn``).
-__all__ = []
+The module exposes a very small, intentionally curated public surface. Everything
+else in the repository is internal and may change without notice.  The exported
+symbols are re-imported here for convenience and documented in
+``docs/api-reference.md``.
+
+Example
+-------
+>>> from govdocverify import DocumentChecker
+>>> checker = DocumentChecker()
+>>> result = checker.run_all_document_checks("path/to.docx")
+>>> result.success
+True
+"""
+
+# Import lightweight items only so tests do not pull heavy optional dependencies.
+from .document_checker import FAADocumentChecker as DocumentChecker
+from .export import save_results_as_docx, save_results_as_pdf
+from .models import DocumentCheckResult, Severity, VisibilitySettings
+
+__all__ = [
+    "DocumentChecker",
+    "DocumentCheckResult",
+    "VisibilitySettings",
+    "Severity",
+    "save_results_as_docx",
+    "save_results_as_pdf",
+]

--- a/tests/test_package_contracts.py
+++ b/tests/test_package_contracts.py
@@ -1,12 +1,45 @@
-"""Placeholder tests for package architecture and contracts."""
+"""Tests covering package architecture and public contracts."""
+
+import importlib
+import sys
 
 import pytest
 
 
-@pytest.mark.skip("PK-01: public API contract enforcement not implemented")
 def test_public_api_contract() -> None:
-    """PK-01: ensure only intended modules are exported."""
-    ...
+    """Ensure only the intended names are exported from :mod:`govdocverify`."""
+    # Import the package fresh to ensure submodules are not already loaded.
+    sys.modules.pop("govdocverify", None)
+    gv = importlib.import_module("govdocverify")
+
+    expected = {
+        "DocumentChecker",
+        "DocumentCheckResult",
+        "VisibilitySettings",
+        "Severity",
+        "save_results_as_docx",
+        "save_results_as_pdf",
+    }
+
+    assert set(gv.__all__) == expected
+
+
+def test_internal_modules_not_exported() -> None:
+    """Ensure internal modules are not surfaced as top-level attributes."""
+    sys.modules.pop("govdocverify", None)
+    gv = importlib.import_module("govdocverify")
+
+    internal_names = {
+        "document_checker",
+        "checks",
+        "cli",
+        "utils",
+        "config",
+    }
+
+    for name in internal_names:
+        assert name not in gv.__all__, f"{name} leaked into __all__"
+        assert not hasattr(gv, name), f"{name} should not be a top-level attribute"
 
 
 @pytest.mark.skip("PK-02: plugin interface contract not implemented")

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -54,6 +54,7 @@ def test_partial_failure_reporting(monkeypatch: pytest.MonkeyPatch) -> None:
     out = build_results_dict(result)
     assert out["partial_failures"][0]["category"] == "readability"
 
+
 def test_graceful_shutdown_under_load(tmp_path: Path) -> None:
     """RE-03: system shuts down gracefully during high load."""
 


### PR DESCRIPTION
## Summary
- expose a minimal, documented public API from `govdocverify`
- add contract tests ensuring only supported names are exported
- document the Python package API in the reference docs

## Testing
- `ruff check govdocverify src tests`
- `black --check govdocverify src tests`
- `mypy --strict src tests`
- `bandit -r src -lll --skip B101` *(fails: command not found)*
- `pip install bandit[toml]` *(fails: Could not find a version that satisfies the requirement bandit[toml])* 
- `semgrep --config p/ci` *(fails: command not found)*
- `pip install semgrep` *(fails: Could not find a version that satisfies the requirement semgrep)*
- `pytest -q -m "not property"`
- `HYPOTHESIS_DEADLINE=0 pytest -q -m property`
- `pytest -q -m e2e`


------
https://chatgpt.com/codex/tasks/task_e_68a1c628ae288332809e39dca2f386cd