### PR TITLE
feat(plugin): introduce plugin interface with contract tests

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,0 +1,33 @@
+# Plugin Interface
+
+GovDocVerify can be extended through a small plugin system. Plugins are
+regular Python classes that inherit from
+`govdocverify.plugins.Plugin`.
+
+## Required Hooks
+
+Every plugin must implement two pieces:
+
+1. **`name` property** – a human friendly identifier for the plugin.
+2. **`register()` method** – called once to allow the plugin to register
+   any checks or other behaviors with the application.
+
+## Example
+
+```python
+from govdocverify.plugins import Plugin
+from govdocverify.checks.check_registry import CheckRegistry
+
+class ExtraChecks(Plugin):
+    @property
+    def name(self) -> str:
+        return "extra-checks"
+
+    def register(self) -> None:
+        @CheckRegistry.register("custom")
+        def my_check(document: str) -> None:
+            ...  # perform additional validation
+```
+
+Plugins should avoid side effects at import time and perform all
+registration within `register()`.

--- a/govdocverify/plugins/__init__.py
+++ b/govdocverify/plugins/__init__.py
@@ -1,0 +1,10 @@
+"""Plugin system for govdocverify.
+
+This package exposes the :class:`~govdocverify.plugins.base.Plugin` base
+class used to build extensions that provide additional checks or
+processing hooks.
+"""
+
+from .base import Plugin
+
+__all__ = ["Plugin"]

--- a/govdocverify/plugins/base.py
+++ b/govdocverify/plugins/base.py
@@ -1,0 +1,45 @@
+"""Plugin interface for :mod:`govdocverify`.
+
+Plugins provide an extension mechanism for :mod:`govdocverify`. A plugin
+is expected to expose a ``name`` property and implement the
+:meth:`register` hook which allows the plugin to wire itself into the
+application (for example by registering new checks with
+:class:`govdocverify.checks.check_registry.CheckRegistry`).
+
+Example::
+
+    from govdocverify.plugins import Plugin
+
+    class MyPlugin(Plugin):
+        # Example plugin that registers custom checks.
+
+        @property
+        def name(self) -> str:
+            return "my-plugin"
+
+        def register(self) -> None:
+            # registration logic goes here
+            ...
+
+Plugins may perform any setup they require inside :meth:`register` but
+should avoid side effects at import time.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class Plugin(ABC):
+    """Abstract base class for GovDocVerify plugins."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human readable name for the plugin."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def register(self) -> None:
+        """Hook for performing plugin registration."""
+        raise NotImplementedError

--- a/src/govdocverify/plugins/__init__.py
+++ b/src/govdocverify/plugins/__init__.py
@@ -1,0 +1,10 @@
+"""Plugin system for govdocverify.
+
+This package exposes the :class:`~govdocverify.plugins.base.Plugin` base
+class used to build extensions that provide additional checks or
+processing hooks.
+"""
+
+from .base import Plugin
+
+__all__ = ["Plugin"]

--- a/src/govdocverify/plugins/base.py
+++ b/src/govdocverify/plugins/base.py
@@ -1,0 +1,45 @@
+"""Plugin interface for :mod:`govdocverify`.
+
+Plugins provide an extension mechanism for :mod:`govdocverify`. A plugin
+is expected to expose a ``name`` property and implement the
+:meth:`register` hook which allows the plugin to wire itself into the
+application (for example by registering new checks with
+:class:`govdocverify.checks.check_registry.CheckRegistry`).
+
+Example::
+
+    from govdocverify.plugins import Plugin
+
+    class MyPlugin(Plugin):
+        # Example plugin that registers custom checks.
+
+        @property
+        def name(self) -> str:
+            return "my-plugin"
+
+        def register(self) -> None:
+            # registration logic goes here
+            ...
+
+Plugins may perform any setup they require inside :meth:`register` but
+should avoid side effects at import time.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+
+class Plugin(ABC):
+    """Abstract base class for GovDocVerify plugins."""
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Human readable name for the plugin."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def register(self) -> None:
+        """Hook for performing plugin registration."""
+        raise NotImplementedError

--- a/tests/test_package_contracts.py
+++ b/tests/test_package_contracts.py
@@ -42,10 +42,24 @@ def test_internal_modules_not_exported() -> None:
         assert not hasattr(gv, name), f"{name} should not be a top-level attribute"
 
 
-@pytest.mark.skip("PK-02: plugin interface contract not implemented")
 def test_plugin_interface_contract() -> None:
     """PK-02: plugin interface validates required hooks."""
-    ...
+    import sys
+    from pathlib import Path
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+    from govdocverify.plugins import Plugin
+
+    class SamplePlugin(Plugin):
+        @property
+        def name(self) -> str:
+            return "sample"
+
+        def register(self) -> None:  # pragma: no cover - no registration logic
+            pass
+
+    plugin = SamplePlugin()
+    assert plugin.name == "sample"
 
 
 @pytest.mark.skip("PK-03: serialization versioning not implemented")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+from govdocverify.plugins import Plugin
+
+
+class GoodPlugin(Plugin):
+    """Example plugin implementing the required hooks."""
+
+    @property
+    def name(self) -> str:
+        return "good"
+
+    def register(self) -> None:  # pragma: no cover - no behaviour
+        pass
+
+
+def test_plugin_instantiation() -> None:
+    plugin = GoodPlugin()
+    assert plugin.name == "good"
+
+
+def test_missing_register_raises() -> None:
+    class NoRegister(Plugin):
+        @property
+        def name(self) -> str:  # pragma: no cover - not executed
+            return "no-register"
+
+    with pytest.raises(TypeError):
+        NoRegister()
+
+
+def test_missing_name_raises() -> None:
+    class NoName(Plugin):
+        def register(self) -> None:  # pragma: no cover - not executed
+            pass
+
+    with pytest.raises(TypeError):
+        NoName()


### PR DESCRIPTION
## Summary
- add abstract `Plugin` base class for extensions
- document plugin hooks and behavior
- validate plugin API via new tests

## Testing
- `ruff check src tests govdocverify/plugins`
- `black --check src tests govdocverify/plugins`
- `mypy --strict src tests`
- `bandit -r src -lll --skip B101` *(fails: command not found)*
- `pip install bandit` *(fails: Tunnel connection failed: 403 Forbidden)*
- `semgrep --config p/ci` *(fails: command not found)*
- `pip install semgrep` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pip install pytest-cov` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q`
- `pytest -q -m property`
- `pytest -q -m e2e`


------
https://chatgpt.com/codex/tasks/task_e_68a1c9c037448332aa7955f0d7ab71a5