### PR TITLE
feat: add serialization versioning to models

### DIFF
--- a/govdocverify/models/checker_result.py
+++ b/govdocverify/models/checker_result.py
@@ -1,10 +1,13 @@
+import json
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, ClassVar, Dict, Optional
 
 
 @dataclass
 class DocumentValidationResults:
     """Keep track of an item's validation status."""
+
+    SERIALIZATION_VERSION: ClassVar[int] = 1
 
     is_valid: bool
     message: str
@@ -27,3 +30,39 @@ class DocumentValidationResults:
             "found": found_watermark,
             "expected": expected_watermark,
         }
+
+    # ---- Serialization helpers -------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the validation results to a dictionary."""
+        return {
+            "version": self.SERIALIZATION_VERSION,
+            "is_valid": self.is_valid,
+            "message": self.message,
+            "found": self.found,
+            "expected": self.expected,
+            "watermark_validation": self.watermark_validation,
+        }
+
+    def to_json(self) -> str:
+        """Serialize the validation results to JSON."""
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "DocumentValidationResults":
+        """Deserialize validation results from a dictionary."""
+        version = int(data.get("version", 0))
+        if version > cls.SERIALIZATION_VERSION:
+            raise ValueError(f"Unsupported DocumentValidationResults version: {version}")
+        return cls(
+            is_valid=data.get("is_valid", False),
+            message=data.get("message", ""),
+            found=data.get("found"),
+            expected=data.get("expected"),
+            watermark_validation=data.get("watermark_validation"),
+        )
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "DocumentValidationResults":
+        """Deserialize validation results from a JSON string."""
+        return cls.from_dict(json.loads(json_str))

--- a/src/govdocverify/models/checker_result.py
+++ b/src/govdocverify/models/checker_result.py
@@ -1,10 +1,13 @@
+import json
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, ClassVar, Dict, Optional
 
 
 @dataclass
 class DocumentValidationResults:
     """Keep track of an item's validation status."""
+
+    SERIALIZATION_VERSION: ClassVar[int] = 1
 
     is_valid: bool
     message: str
@@ -27,3 +30,39 @@ class DocumentValidationResults:
             "found": found_watermark,
             "expected": expected_watermark,
         }
+
+    # ---- Serialization helpers -------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize the validation results to a dictionary."""
+        return {
+            "version": self.SERIALIZATION_VERSION,
+            "is_valid": self.is_valid,
+            "message": self.message,
+            "found": self.found,
+            "expected": self.expected,
+            "watermark_validation": self.watermark_validation,
+        }
+
+    def to_json(self) -> str:
+        """Serialize the validation results to JSON."""
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "DocumentValidationResults":
+        """Deserialize validation results from a dictionary."""
+        version = int(data.get("version", 0))
+        if version > cls.SERIALIZATION_VERSION:
+            raise ValueError(f"Unsupported DocumentValidationResults version: {version}")
+        return cls(
+            is_valid=data.get("is_valid", False),
+            message=data.get("message", ""),
+            found=data.get("found"),
+            expected=data.get("expected"),
+            watermark_validation=data.get("watermark_validation"),
+        )
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "DocumentValidationResults":
+        """Deserialize validation results from a JSON string."""
+        return cls.from_dict(json.loads(json_str))

--- a/tests/test_checker_result_model.py
+++ b/tests/test_checker_result_model.py
@@ -11,3 +11,18 @@ def test_watermark_addition() -> None:
         "found": "foo",
         "expected": "foo",
     }
+
+
+def test_serialization_roundtrip() -> None:
+    dvr = DocumentValidationResults(is_valid=False, message="oops")
+    data = dvr.to_dict()
+    assert data["version"] == DocumentValidationResults.SERIALIZATION_VERSION
+    restored = DocumentValidationResults.from_dict(data)
+    assert restored == dvr
+
+
+def test_serialization_legacy_input() -> None:
+    legacy = {"is_valid": True, "message": "ok"}
+    restored = DocumentValidationResults.from_dict(legacy)
+    assert restored.is_valid is True
+    assert restored.message == "ok"

--- a/tests/test_package_contracts.py
+++ b/tests/test_package_contracts.py
@@ -3,8 +3,6 @@
 import importlib
 import sys
 
-import pytest
-
 
 def test_public_api_contract() -> None:
     """Ensure only the intended names are exported from :mod:`govdocverify`."""
@@ -62,7 +60,10 @@ def test_plugin_interface_contract() -> None:
     assert plugin.name == "sample"
 
 
-@pytest.mark.skip("PK-03: serialization versioning not implemented")
 def test_serialization_versioning() -> None:
     """PK-03: serialized data includes version metadata."""
-    ...
+    from govdocverify.models import DocumentCheckResult
+
+    res = DocumentCheckResult(success=True)
+    data = res.to_dict()
+    assert data["version"] == DocumentCheckResult.SERIALIZATION_VERSION

--- a/tests/test_serialization_versions.py
+++ b/tests/test_serialization_versions.py
@@ -1,0 +1,31 @@
+import pytest
+
+from govdocverify.models import DocumentCheckResult, Severity
+
+
+def test_document_check_result_round_trip() -> None:
+    res = DocumentCheckResult(
+        success=False,
+        issues=[{"message": "m", "severity": Severity.WARNING, "line_number": 1, "category": "c"}],
+        checker_name="checker",
+        score=0.5,
+        severity=Severity.WARNING,
+        details={"x": 1},
+    )
+    data = res.to_dict()
+    assert data["version"] == DocumentCheckResult.SERIALIZATION_VERSION
+    restored = DocumentCheckResult.from_dict(data)
+    assert restored == res
+
+
+def test_document_check_result_deserialize_legacy() -> None:
+    legacy = {"success": True, "issues": [], "checker_name": "old"}
+    res = DocumentCheckResult.from_dict(legacy)
+    assert res.success is True
+    assert res.checker_name == "old"
+
+
+def test_document_check_result_rejects_future_version() -> None:
+    data = {"version": 999, "success": True, "issues": []}
+    with pytest.raises(ValueError):
+        DocumentCheckResult.from_dict(data)


### PR DESCRIPTION
## Summary
- add version metadata and serialization helpers to `DocumentCheckResult`, `VisibilitySettings`, and `DocumentValidationResults`
- ensure backward-compatible deserialization for legacy data
- add tests for serialization versioning and remove package contract skip

## Testing
- `make lint`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1cd5045d48332a80c6ee67ab2ac9a