### PR TITLE
Add STRICT_MODE flag for batch validation

### DIFF
--- a/govdocverify/cli.py
+++ b/govdocverify/cli.py
@@ -106,8 +106,12 @@ def process_document(  # noqa: C901 - function is complex but mirrors CLI logic
 
         # Return a dictionary with the expected structure for tests
         has_errors = not results.success if hasattr(results, "success") else False
+        severity_name = (
+            results.severity.name if getattr(results, "severity", None) is not None else None
+        )
         return {
             "has_errors": has_errors,
+            "severity": severity_name,
             "rendered": formatted_results,
             "by_category": filtered_results_dict,
             "metadata": metadata,

--- a/src/govdocverify/cli.py
+++ b/src/govdocverify/cli.py
@@ -103,8 +103,12 @@ def process_document(  # noqa: C901 - function is complex but mirrors CLI logic
 
         # Return a dictionary with the expected structure for tests
         has_errors = not results.success if hasattr(results, "success") else False
+        severity_name = (
+            results.severity.name if getattr(results, "severity", None) is not None else None
+        )
         return {
             "has_errors": has_errors,
+            "severity": severity_name,
             "rendered": formatted_results,
             "by_category": filtered_results_dict,
             "metadata": metadata,


### PR DESCRIPTION
## Summary
- expose result severity from CLI processing
- gate batch processing with STRICT_MODE environment flag
- add tests covering strict mode behaviour and E2E batch gating

## Testing
- `pytest tests/test_ci_scenarios.py tests/test_e2e_scenarios.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a1e155a9308332ac2ab0eb85603861