### PR TITLE
chore/ci: enforce coverage thresholds in tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,7 @@ shell    = ["os.system", "subprocess.Popen"]
 [tool.pytest.ini_options]
 testpaths     = ["tests"]
 python_files  = "test_*.py"
+addopts       = "--cov=govdocverify --cov-branch --cov-fail-under=70"
 markers       = [
   "property: property-based tests",
   "e2e: end-to-end tests",

--- a/tests/test_e2e_scenarios.py
+++ b/tests/test_e2e_scenarios.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 from pathlib import Path
 
-import pytest
 from fastapi.testclient import TestClient
 
 from backend.main import app
@@ -20,8 +19,14 @@ def test_cli_single_file_run(tmp_path: Path) -> None:
     script = (
         "import json, sys\n"
         "from govdocverify import cli\n"
-        "def stub_process_document(file_path, doc_type, visibility_settings=None, group_by='category'):\n"
-        "    return {'has_errors': True, 'rendered': 'stub', 'by_category': {}, 'metadata': {}}\n"
+        "def stub_process_document(file_path, doc_type,\n"
+        "    visibility_settings=None, group_by='category'):\n"
+        "    return {\n"
+        "        'has_errors': True,\n"
+        "        'rendered': 'stub',\n"
+        "        'by_category': {},\n"
+        "        'metadata': {}\n"
+        "    }\n"
         "cli.process_document = stub_process_document\n"
         "sys.argv = ['cli.py', '--file', sys.argv[1], '--type', 'ORDER', '--json']\n"
         "raise SystemExit(cli.main())\n"

--- a/tests/test_quality_gates.py
+++ b/tests/test_quality_gates.py
@@ -1,9 +1,51 @@
-"""Placeholder tests for coverage and quality gate enforcement."""
+"""Ensure coverage thresholds are enforced."""
 
-import pytest
+from __future__ import annotations
+
+import subprocess
+import sys
+from textwrap import dedent
 
 
-@pytest.mark.skip("Coverage threshold enforcement not implemented")
-def test_coverage_threshold_enforced() -> None:
-    """Placeholder ensuring coverage thresholds are checked in CI."""
-    ...
+def _run_pytest(tmp_path, threshold: int, source: str) -> subprocess.CompletedProcess[str]:
+    """Run pytest in *tmp_path* with the given coverage *threshold*."""
+    module = tmp_path / "module.py"
+    module.write_text(dedent(source))
+    test_file = tmp_path / "test_module.py"
+    test_file.write_text("from module import func\n\n" "def test_func() -> None:\n" "    func()\n")
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "--cov=.",
+        "--cov-branch",
+        f"--cov-fail-under={threshold}",
+    ]
+    return subprocess.run(cmd, cwd=tmp_path, text=True, capture_output=True)
+
+
+def test_coverage_threshold_enforced(tmp_path):
+    """Pytest exits with non-zero status when coverage is too low."""
+    source = """
+    from typing import NoReturn
+
+    def func() -> None:
+        if False:  # pragma: no cover
+            _unreachable()
+
+    def _unreachable() -> NoReturn:
+        raise RuntimeError
+    """
+    result = _run_pytest(tmp_path, 100, source)
+    assert result.returncode != 0
+    assert "required test coverage of 100%" in result.stdout
+
+
+def test_coverage_threshold_met(tmp_path):
+    """Pytest passes when coverage requirement is satisfied."""
+    source = """
+    def func() -> None:
+        pass
+    """
+    result = _run_pytest(tmp_path, 50, source)
+    assert result.returncode == 0


### PR DESCRIPTION
## Summary
- enforce 70% coverage with pytest-cov
- add tests verifying coverage threshold behaviour
- tidy E2E scenario script for lint compliance

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src tests`
- `bandit -r src -lll --skip B101` *(fails: command not found)*
- `semgrep --config p/ci` *(fails: command not found)*
- `pytest -q` *(fails: unrecognized arguments --cov=govdocverify --cov-branch --cov-fail-under=70)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e49570808332bc4fa6f20f406fb1