### PR TITLE
Assign severity to heading warnings

### DIFF
--- a/govdocverify/checks/heading_checks.py
+++ b/govdocverify/checks/heading_checks.py
@@ -181,6 +181,7 @@ class HeadingChecks(BaseChecker):
                         f"Shorten heading to {self.MAX_HEADING_LENGTH} characters or less."
                     ),
                     "category": self.category,
+                    "severity": Severity.WARNING,
                 }
             )
             return False
@@ -202,6 +203,7 @@ class HeadingChecks(BaseChecker):
                         f"{', '.join(sorted(heading_words))}"
                     ),
                     "category": self.category,
+                    "severity": Severity.WARNING,
                 }
             )
             return False
@@ -220,6 +222,7 @@ class HeadingChecks(BaseChecker):
                     "message": "Heading should be uppercase",
                     "suggestion": line.split(".", 1)[0] + ". " + heading_text.upper(),
                     "category": self.category,
+                    "severity": Severity.WARNING,
                 }
             )
         else:
@@ -235,6 +238,7 @@ class HeadingChecks(BaseChecker):
                         "message": "Heading formatting issue",
                         "suggestion": normalized,
                         "category": self.category,
+                        "severity": Severity.WARNING,
                     }
                 )
 


### PR DESCRIPTION
## Summary
- mark heading length, word, case, and format issues as warnings
- treat warning issues as failures in heading check tests

## Testing
- `pytest -q -o addopts='' tests/test_heading_checks.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1e67c42208332b4012eaab0ea61d7