### PR TITLE
feat/structure: validate watermark stage

### DIFF
--- a/govdocverify/checks/structure_checks.py
+++ b/govdocverify/checks/structure_checks.py
@@ -515,6 +515,27 @@ class StructureChecks(BaseChecker):
             )
             return
 
+        normalized_found = self._normalize_watermark_text(watermark_text)
+        requirement = next((w for w in self.VALID_WATERMARKS if w.doc_stage == doc_type), None)
+
+        if requirement:
+            expected_normalized = self._normalize_watermark_text(requirement.text)
+            if normalized_found != expected_normalized:
+                results.add_issue(
+                    message=StructureMessages.WATERMARK_INCORRECT.format(
+                        expected=requirement.text, doc_type=doc_type
+                    ),
+                    severity=Severity.ERROR,
+                    line_number=1,
+                    found=watermark_text,
+                )
+        else:
+            results.add_issue(
+                message=StructureMessages.WATERMARK_UNKNOWN_STAGE.format(doc_type=doc_type),
+                severity=Severity.WARNING,
+                line_number=1,
+            )
+
     def _extract_watermark(self, doc: DocxDocument) -> Optional[str]:
         """Extract watermark text from the document body, headers, and footers."""
 

--- a/src/govdocverify/checks/structure_checks.py
+++ b/src/govdocverify/checks/structure_checks.py
@@ -496,6 +496,27 @@ class StructureChecks(BaseChecker):
             )
             return
 
+        normalized_found = self._normalize_watermark_text(watermark_text)
+        requirement = next((w for w in self.VALID_WATERMARKS if w.doc_stage == doc_type), None)
+
+        if requirement:
+            expected_normalized = self._normalize_watermark_text(requirement.text)
+            if normalized_found != expected_normalized:
+                results.add_issue(
+                    message=StructureMessages.WATERMARK_INCORRECT.format(
+                        expected=requirement.text, doc_type=doc_type
+                    ),
+                    severity=Severity.ERROR,
+                    line_number=1,
+                    found=watermark_text,
+                )
+        else:
+            results.add_issue(
+                message=StructureMessages.WATERMARK_UNKNOWN_STAGE.format(doc_type=doc_type),
+                severity=Severity.WARNING,
+                line_number=1,
+            )
+
     def _extract_watermark(self, doc: DocxDocument) -> Optional[str]:
         """Extract watermark text from the document body, headers, and footers."""
 


### PR DESCRIPTION
## Summary
- validate document watermarks against expected stage
- warn on unknown document stages and error on mismatched watermarks
- adjust watermark tests for new validation behavior

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src tests`
- `bandit -r src -lll --skip B101` *(fails: command not found)*
- `pip install bandit` *(fails: Could not find a version that satisfies the requirement bandit)*
- `semgrep --config p/ci` *(fails: command not found)*
- `pip install semgrep` *(fails: Could not find a version that satisfies the requirement semgrep)*
- `pytest -q -o addopts=""` *(fails: 5 failed, 435 passed, 3 skipped, 2 xfailed, 2 xpassed)*
- `pytest -q -m property -o addopts=""`
- `pytest -q -m e2e -o addopts=""`


------
https://chatgpt.com/codex/tasks/task_e_68a1ef24a9908332a55aa1b01f9861c0