### PR TITLE
test(checks): add integration test using public APIs

### DIFF
--- a/tests/test_full_checker_integration.py
+++ b/tests/test_full_checker_integration.py
@@ -1,0 +1,20 @@
+from docx import Document
+
+from govdocverify.document_checker import FAADocumentChecker
+
+
+def test_run_all_checks(tmp_path):
+    doc = Document()
+    doc.add_paragraph("1. INTRODUCTION", style="Heading 1")
+    doc.add_paragraph(
+        "This paragraph intentionally uses complex wording to lower readability scores."
+    )
+    path = tmp_path / "integration.docx"
+    doc.save(path)
+
+    checker = FAADocumentChecker()
+    result = checker.run_all_document_checks(str(path), doc_type="internal_review")
+
+    categories = [cat for _, cat in checker._get_check_modules()]
+    assert set(categories).issubset(result.per_check_results.keys())
+    assert result.issues and all("severity" in issue for issue in result.issues)


### PR DESCRIPTION
## Summary
- exercise StructureChecks via public APIs
- add integration test for full checker execution

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict tests/test_full_checker_integration.py tests/test_structure_checks.py`
- `pytest -q tests/test_structure_checks.py tests/test_full_checker_integration.py -o addopts=""`
- `pytest -q -m property -o addopts=""`
- `pytest -q -m e2e -o addopts=""`
- `pip install bandit` *(failed: Could not connect to proxy)*
- `pip install semgrep` *(failed: Could not connect to proxy)*
- `pip install pytest-cov` *(failed: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68a21baf0c208332b33cdbad3f616d11