### PR TITLE
docs: update Python version references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ any check fails. Re-run the commit after fixing the reported issues.
 ## Development Setup
 
 1. Clone the repository
-2. Set up Python 3.11+ environment (recommended: use virtual environment)
+2. Set up a Python 3.11–3.13 environment (3.12 recommended)
    ```bash
    python -m venv venv
    source venv/bin/activate  # On Windows: venv\Scripts\activate

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Prefer to do the steps manually? We follow the same pattern as the other CLI pro
 
 ```bash
 # 0. One-time setup: Python & pipx -------------------------------------------------
-python --version                # confirm Python ≥3.13
+python --version                # confirm Python 3.11–3.13
 python -m pip install --user pipx
 python -m pipx ensurepath       # restart shell if PATH changes
 pipx install uv                 # fast resolver, venv mgr, lockfile, tool runner
@@ -40,9 +40,9 @@ pipx install uv                 # fast resolver, venv mgr, lockfile, tool runner
 git clone https://github.com/eputnam77/GovDocVerify.git
 cd GovDocVerify
 
-# 2. Create and activate venv (Python 3.13) --------------------------------------
-uv python install 3.13.0        # Download if not present
-uv venv --python 3.13.0
+# 2. Create and activate venv (Python 3.12) --------------------------------------
+uv python install 3.12          # Download if not present
+uv venv --python 3.12
 # Activate the venv:
 #   On Windows:
 .venv\Scripts\activate

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,7 +3,7 @@
 This guide walks you through installing dependencies and running the application.
 
 ## Requirements
-- Python 3.11+
+- Python 3.11–3.13 (3.12 recommended)
 - Node 18+ for the React frontend
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
- recommend Python 3.12 in README and clarify supported range 3.11–3.13
- align contributing and getting-started docs with supported Python versions

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src tests`
- `pre-commit run --files README.md CONTRIBUTING.md docs/getting-started.md` *(fails: command not found)*
- `bandit -r src -lll --skip B101` *(fails: command not found)
- `semgrep --config p/ci` *(fails: command not found)*
- `pytest -q --cov=govdocverify --cov-branch --cov-fail-under=70` *(fails: unrecognized arguments)*
- `pytest -q -m property` *(fails: unrecognized arguments)*
- `pytest -q -m e2e` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d8367ea88332ae52ac244f258450