### PR TITLE
docs: clarify repository root

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ FAA‑style validation for Word docs—CLI, FastAPI, and React UI in one toolkit
 
 Full technical docs live under **`docs/`**; start with *docs/getting‑started.md* when you’re ready to dig deeper.
 
+After cloning, change into the `GovDocVerify` directory. All commands in this README assume you’re in the repository root—not inside `src`.
+
 ## 📄 Supported document formats
 
 GovDocVerify accepts only modern `.docx` files. Legacy formats—such as `.doc`, `.pdf`, `.rtf`, and `.txt`—are rejected during validation.


### PR DESCRIPTION
## Summary
- document that all commands should run from the `GovDocVerify` root directory, not `src`

## Testing
- `pre-commit run --files README.md` *(fails: command not found)*
- `pytest --override-ini=addopts='' test_format_checks.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4da5deae08332b11c369f5de8f41a