### PR TITLE
fix: improve phone format detection and severity handling

### DIFF
--- a/govdocverify/checks/format_checks.py
+++ b/govdocverify/checks/format_checks.py
@@ -155,18 +155,20 @@ class FormatChecks(BaseChecker):
 
     def _collect_phone_numbers_from_paragraphs(self, paragraphs: list) -> list:
         """Collect all phone numbers and their styles from paragraphs."""
-        found = []  # (line_number, style)
-
+        found: list[tuple[int, str]] = []
         for idx, line in enumerate(paragraphs, start=1):
+            seen_spans: set[tuple[int, int]] = set()
             for pattern in PHONE_PATTERNS:
-                if match := re.search(pattern, line):
+                for match in re.finditer(pattern, line):
+                    span = match.span()
+                    if span in seen_spans:
+                        continue
+                    seen_spans.add(span)
                     style = self._categorise_phone_number_in_paragraph(match.group(0))
                     logger.debug(
                         f"Found phone number in line {idx}: {match.group(0)} (style={style})"
                     )
                     found.append((idx, style))
-                    break  # Only add each number once
-
         return found
 
     def _categorise_phone_number_in_paragraph(self, num: str) -> str:
@@ -380,12 +382,12 @@ class FormatChecks(BaseChecker):
 
     def _get_font_type(self, line: str) -> str:
         """Determine font type of a line."""
-        # Be case-insensitive when looking for formatting markers.  The
-        # previous implementation only matched an uppercase ``BOLD`` token,
-        # causing lines containing "bold" in lowercase to be treated as normal
-        # text and escaping the font consistency check.
+        # Be case-insensitive when looking for formatting markers and ensure
+        # we only match them as standalone words.  The previous implementation
+        # used substring checks which misclassified words like "boldness" as
+        # special formatting.
         text = line.lower()
-        if "bold" in text or "italic" in text:
+        if re.search(r"\b(bold|italic)\b", text):
             return "special"
         return "normal"
 

--- a/govdocverify/models/__init__.py
+++ b/govdocverify/models/__init__.py
@@ -116,7 +116,10 @@ class DocumentCheckResult:
                     f"Assigned category: '{issue['category']}'. "
                     f"Issue details: {issue}"
                 )
-        self.severity = None  # Will be set on first issue
+        # ``severity`` might be provided by callers that already know the
+        # overall state.  The previous implementation unconditionally reset it
+        # to ``None`` here, discarding that information.  Preserve the supplied
+        # value and leave it unchanged until issues are added.
 
     def add_issue(
         self,

--- a/src/govdocverify/models.py
+++ b/src/govdocverify/models.py
@@ -74,7 +74,10 @@ class DocumentCheckResult:
             self.issues = []
         if self.partial_failures is None:
             self.partial_failures = []
-        self.severity = None  # Will be set on first issue
+        # ``severity`` may be supplied by the caller.  The previous
+        # implementation always reset it to ``None`` here, discarding any
+        # pre‑set value.  Only leave it as ``None`` when it wasn't provided.
+        # It will still be updated when issues are added.
 
     def add_issue(
         self,

--- a/src/govdocverify/models/__init__.py
+++ b/src/govdocverify/models/__init__.py
@@ -116,7 +116,8 @@ class DocumentCheckResult:
                     f"Assigned category: '{issue['category']}'. "
                     f"Issue details: {issue}"
                 )
-        self.severity = None  # Will be set on first issue
+        # Preserve any severity supplied by the caller instead of resetting it
+        # to ``None``. It will still be updated when new issues are added.
 
     def add_issue(
         self,

--- a/tests/test_models_root.py
+++ b/tests/test_models_root.py
@@ -49,3 +49,10 @@ def test_issue_dataclass_and_pattern_config() -> None:
     assert pc.pattern == "foo"
     issue = models.Issue(message="msg")
     assert issue.message == "msg"
+
+
+def test_document_check_result_preserves_initial_severity() -> None:
+    from govdocverify.models import DocumentCheckResult, Severity
+
+    res = DocumentCheckResult(success=True, severity=Severity.WARNING)
+    assert res.severity == Severity.WARNING


### PR DESCRIPTION
## Summary
- preserve initial severity in `DocumentCheckResult`
- detect multiple phone-number styles on the same line
- avoid false font warnings for words like "boldness"

## Testing
- `ruff check src tests`
- `black --check govdocverify/models/__init__.py src/govdocverify/models/__init__.py govdocverify/checks/format_checks.py src/govdocverify/checks/format_checks.py tests/test_formats.py tests/test_models_root.py`
- `mypy --strict src tests`
- `bandit -r src -lll --skip B101` *(command not found)*
- `semgrep --config p/ci` *(command not found)*
- `pytest -q`
- `pytest -q -m property`
- `pytest -q -m e2e`

------
https://chatgpt.com/codex/tasks/task_e_68aa560318cc83328f260e52f4f05ba3