### PR TITLE
fix: validate 508 content types

### DIFF
--- a/src/govdocverify/checks/heading_checks.py
+++ b/src/govdocverify/checks/heading_checks.py
@@ -79,9 +79,7 @@ class HeadingChecks(BaseChecker):
             combined.issues.append(issue)
             combined.success = False
             sev = issue.get("severity")
-            if isinstance(sev, Severity) and (
-                combined.severity is None or sev < combined.severity
-            ):
+            if isinstance(sev, Severity) and (combined.severity is None or sev < combined.severity):
                 combined.severity = sev
 
         return combined

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -45,10 +45,7 @@ class TestFormattingChecks:
             "Back to normal.",
         ]
         result = self.format_checks.check(content)
-        assert any(
-            "inconsistent font" in issue["message"].lower()
-            for issue in result["warnings"]
-        )
+        assert any("inconsistent font" in issue["message"].lower() for issue in result["warnings"])
 
     def test_spacing_consistency(self):
         content = [

--- a/tests/test_heading_checks.py
+++ b/tests/test_heading_checks.py
@@ -158,10 +158,7 @@ class TestHeadingChecks:
         text = "1. Introduction\nSome content."
         result = self.heading_checks.check_text(text)
         assert not result.success
-        assert any(
-            "approved heading word" in issue["message"].lower()
-            for issue in result.issues
-        )
+        assert any("approved heading word" in issue["message"].lower() for issue in result.issues)
 
     def test_document_type_matching(self):
         """Test document type matching with different case variations."""


### PR DESCRIPTION
## Summary
- validate 508 compliance input to ensure all items are strings
- harden color contrast and markdown alt-text checks against non-string content
- add tests for 508 content validation and robustness

## Testing
- `ruff check src tests govdocverify`
- `black --check src/govdocverify/checks/accessibility_checks.py govdocverify/checks/accessibility_checks.py src/govdocverify/checks/heading_checks.py tests/test_formatting.py tests/test_heading_checks.py tests/test_accessibility_checks.py`
- `mypy --strict govdocverify/checks/accessibility_checks.py`
- `mypy --strict src tests`
- `pytest -q`
- `pytest -q -m property`
- `pytest -q -m e2e`


------
https://chatgpt.com/codex/tasks/task_e_68aa59b2acb48332882f632188a98694