### PR TITLE
fix: handle optional dependency fallbacks

### DIFF
--- a/govdocverify/checks/format_checks.py
+++ b/govdocverify/checks/format_checks.py
@@ -3,9 +3,9 @@ import re
 from typing import Any, Dict, List
 
 try:
-    from docx import Document  # type: ignore
-except Exception:  # pragma: no cover - optional dependency
-    from typing import Any as Document  # type: ignore
+    from docx import Document
+except ImportError:  # pragma: no cover - optional dependency
+    Document = Any
 
 
 from govdocverify.checks.check_registry import CheckRegistry

--- a/govdocverify/export.py
+++ b/govdocverify/export.py
@@ -8,8 +8,8 @@ from typing import Any
 from docx import Document
 
 try:  # Optional dependency for PDF export
-    from fpdf import FPDF  # type: ignore
-except Exception:  # pragma: no cover - dependency might be missing
+    from fpdf import FPDF
+except ImportError:  # pragma: no cover - dependency might be missing
     FPDF = None
 
 

--- a/govdocverify/utils/formatting.py
+++ b/govdocverify/utils/formatting.py
@@ -4,8 +4,8 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 try:
-    from colorama import Fore, Style  # type: ignore
-except Exception:  # pragma: no cover - optional dependency
+    from colorama import Fore, Style
+except ImportError:  # pragma: no cover - optional dependency
 
     class _DummyFore:
         BLACK = RED = GREEN = YELLOW = BLUE = MAGENTA = CYAN = WHITE = ""

--- a/src/govdocverify/checks/format_checks.py
+++ b/src/govdocverify/checks/format_checks.py
@@ -3,9 +3,9 @@ import re
 from typing import Any, Dict, List
 
 try:
-    from docx import Document  # type: ignore
-except Exception:  # pragma: no cover - optional dependency
-    from typing import Any as Document  # type: ignore
+    from docx import Document
+except ImportError:  # pragma: no cover - optional dependency
+    Document = Any
 
 
 from govdocverify.checks.check_registry import CheckRegistry

--- a/src/govdocverify/export.py
+++ b/src/govdocverify/export.py
@@ -8,8 +8,8 @@ from typing import Any
 from docx import Document
 
 try:  # Optional dependency for PDF export
-    from fpdf import FPDF  # type: ignore
-except Exception:  # pragma: no cover - dependency might be missing
+    from fpdf import FPDF
+except ImportError:  # pragma: no cover - dependency might be missing
     FPDF = None
 
 

--- a/src/govdocverify/utils/formatting.py
+++ b/src/govdocverify/utils/formatting.py
@@ -4,8 +4,8 @@ from enum import Enum
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 try:
-    from colorama import Fore, Style  # type: ignore
-except Exception:  # pragma: no cover - optional dependency
+    from colorama import Fore, Style
+except ImportError:  # pragma: no cover - optional dependency
 
     class _DummyFore:
         BLACK = RED = GREEN = YELLOW = BLUE = MAGENTA = CYAN = WHITE = ""

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -1,0 +1,63 @@
+"""Tests ensuring optional dependencies degrade gracefully."""
+
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+from pathlib import Path
+
+
+def test_formatter_without_colorama(monkeypatch):
+    """Formatter works when colorama isn't installed."""
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "colorama":
+            raise ModuleNotFoundError
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    orig_module = sys.modules.pop("govdocverify.utils.formatting", None)
+    fmt_module = importlib.import_module("govdocverify.utils.formatting")
+    formatter = fmt_module.ResultFormatter()
+    assert fmt_module.Fore.RED == ""
+    assert formatter._format_colored_text("hi", fmt_module.Fore.RED) == "hi"
+    if orig_module is not None:
+        sys.modules["govdocverify.utils.formatting"] = orig_module
+    monkeypatch.setattr(builtins, "__import__", orig_import)
+
+
+def test_format_checks_without_docx(monkeypatch):
+    """Format checks run with a minimal document when python-docx is missing."""
+    orig_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "docx":
+            raise ModuleNotFoundError
+        return orig_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    orig_module = sys.modules.pop("govdocverify.checks.format_checks", None)
+    fc_module = importlib.import_module("govdocverify.checks.format_checks")
+
+    class DummyDoc:
+        paragraphs: list[str] = []
+
+    checker = fc_module.FormatChecks()
+    results = fc_module.DocumentCheckResult()
+    checker.run_checks(DummyDoc(), "AC", results)
+    assert results.success
+    if orig_module is not None:
+        sys.modules["govdocverify.checks.format_checks"] = orig_module
+    monkeypatch.setattr(builtins, "__import__", orig_import)
+
+
+def test_save_results_as_pdf_without_fpdf(tmp_path: Path, monkeypatch):
+    """PDF export writes a minimal file when fpdf isn't installed."""
+    from govdocverify import export
+
+    monkeypatch.setattr(export, "FPDF", None)
+    output = tmp_path / "out.pdf"
+    export.save_results_as_pdf({"a": 1}, str(output))
+    assert output.read_bytes().startswith(b"%PDF-1.4")


### PR DESCRIPTION
## Summary
- handle missing optional dependencies without type ignores
- add tests covering colorama, python-docx, and fpdf fallbacks

## Testing
- `ruff check src tests`
- `black --check src tests`
- `mypy --strict src tests`
- `bandit -r src -lll --skip B101` *(fails: command not found)*
- `semgrep --config p/ci` *(fails: command not found)*
- `pytest -q`
- `pytest -q -m property`
- `pytest -q -m e2e`
- `pytest -q --cov=govdocverify --cov-branch --cov-fail-under=70` *(fails: unrecognized arguments)*
- `python test_format_checks.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa5e47a3d08332b60612e9892ff987