### PR TITLE
Improve model parsing and test coverage

### DIFF
--- a/govdocverify/models/__init__.py
+++ b/govdocverify/models/__init__.py
@@ -65,9 +65,9 @@ class DocumentType(str, Enum):
 
         # Normalize the input string:
         # 1. Strip leading/trailing whitespace
-        # 2. Replace multiple spaces/newlines/tabs with single space
+        # 2. Replace underscores/hyphens/whitespace with single space
         # 3. Title case the string
-        normalized = re.sub(r"\s+", " ", doc_type.strip()).title()
+        normalized = re.sub(r"[\s_-]+", " ", doc_type.strip()).title()
 
         # Try direct value match first
         for member in cls:
@@ -215,17 +215,25 @@ class DocumentCheckResult:
         if version > cls.SERIALIZATION_VERSION:
             raise ValueError(f"Unsupported DocumentCheckResult version: {version}")
 
+        def _parse_severity(value: Any) -> Any:
+            if isinstance(value, Severity):
+                return value
+            if isinstance(value, int):
+                return Severity(value)
+            if isinstance(value, str):
+                try:
+                    return Severity[value.strip().replace(" ", "_").upper()]
+                except KeyError:
+                    pass
+            return value
+
         issues: List[Dict[str, Any]] = []
         for issue in data.get("issues", []):
             new_issue = issue.copy()
-            sev = new_issue.get("severity")
-            if isinstance(sev, int):
-                new_issue["severity"] = Severity(sev)
+            new_issue["severity"] = _parse_severity(new_issue.get("severity"))
             issues.append(new_issue)
 
-        severity = data.get("severity")
-        if isinstance(severity, int):
-            severity = Severity(severity)
+        severity = _parse_severity(data.get("severity"))
 
         return cls(
             success=data.get("success", True),
@@ -289,17 +297,29 @@ class VisibilitySettings:
         if version > cls.SERIALIZATION_VERSION:
             raise ValueError(f"Unsupported VisibilitySettings version: {version}")
 
+        def _bool(key: str, default: bool) -> bool:
+            val = settings.get(key, default)
+            if isinstance(val, bool):
+                return val
+            if isinstance(val, str):
+                lowered = val.strip().lower()
+                if lowered in {"true", "1", "yes", "y"}:
+                    return True
+                if lowered in {"false", "0", "no", "n"}:
+                    return False
+            return bool(val) if isinstance(val, (int, float)) else default
+
         return cls(
-            show_readability=settings.get("readability", True),
-            show_analysis=settings.get("analysis", True),
-            show_paragraph_length=settings.get("paragraph_length", True),
-            show_terminology=settings.get("terminology", True),
-            show_headings=settings.get("headings", True),
-            show_structure=settings.get("structure", True),
-            show_format=settings.get("format", True),
-            show_accessibility=settings.get("accessibility", True),
-            show_document_status=settings.get("document_status", True),
-            show_acronym=settings.get("acronym", True),
+            show_readability=_bool("readability", True),
+            show_analysis=_bool("analysis", True),
+            show_paragraph_length=_bool("paragraph_length", True),
+            show_terminology=_bool("terminology", True),
+            show_headings=_bool("headings", True),
+            show_structure=_bool("structure", True),
+            show_format=_bool("format", True),
+            show_accessibility=_bool("accessibility", True),
+            show_document_status=_bool("document_status", True),
+            show_acronym=_bool("acronym", True),
         )
 
     @classmethod

--- a/tests/property/test_extract_docx_metadata.py
+++ b/tests/property/test_extract_docx_metadata.py
@@ -12,7 +12,7 @@ ascii_chars = st.characters(min_codepoint=32, max_codepoint=126)
 
 
 @pytest.mark.property
-@settings(suppress_health_check=[HealthCheck.function_scoped_fixture])
+@settings(suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=None)
 @given(
     title=st.text(min_size=1, max_size=20, alphabet=ascii_chars),
     author=st.text(min_size=1, max_size=20, alphabet=ascii_chars),

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -51,6 +51,8 @@ class TestDocumentType(unittest.TestCase):
             ("Special Condition", DocumentType.SPECIAL_CONDITION),
             ("Technical Standard Order", DocumentType.TECHNICAL_STANDARD_ORDER),
             ("Other", DocumentType.OTHER),
+            ("Advisory-Circular", DocumentType.ADVISORY_CIRCULAR),
+            ("Advisory_Circular", DocumentType.ADVISORY_CIRCULAR),
         ]
 
         for input_str, expected in test_cases:
@@ -69,8 +71,6 @@ class TestDocumentType(unittest.TestCase):
             "Test",
             "Advisory",  # Partial match
             "Circular",  # Partial match
-            "Advisory-Circular",  # Wrong format
-            "Advisory_Circular",  # Wrong format
             "",  # Empty string
             " ",  # Whitespace
             None,  # None value

--- a/tests/test_models_updates.py
+++ b/tests/test_models_updates.py
@@ -1,0 +1,70 @@
+import importlib
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+# load src module for parity
+
+def _load_src(module: str):
+    base = Path(__file__).resolve().parents[1] / "src" / module
+    spec = importlib.util.spec_from_file_location(module.replace("/", "."), base)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(mod)
+    return mod
+
+models = importlib.import_module("govdocverify.models")
+src_models = _load_src("govdocverify/models/__init__.py")
+
+DocumentType = models.DocumentType
+DocumentCheckResult = models.DocumentCheckResult
+Severity = models.Severity
+VisibilitySettings = models.VisibilitySettings
+
+src_DocumentType = src_models.DocumentType
+src_DocumentCheckResult = src_models.DocumentCheckResult
+src_Severity = src_models.Severity
+src_VisibilitySettings = src_models.VisibilitySettings
+
+
+@pytest.mark.parametrize("mod_DocumentType", [DocumentType, src_DocumentType])
+def test_document_type_from_string_handles_delimiters(mod_DocumentType):
+    assert (
+        mod_DocumentType.from_string("special-condition")
+        == mod_DocumentType.SPECIAL_CONDITION
+    )
+    assert (
+        mod_DocumentType.from_string("special_condition")
+        == mod_DocumentType.SPECIAL_CONDITION
+    )
+
+
+@pytest.mark.parametrize(
+    "DCR, Sev",
+    [
+        (DocumentCheckResult, Severity),
+        (src_DocumentCheckResult, src_Severity),
+    ],
+)
+def test_document_check_result_from_dict_accepts_string_severity(DCR, Sev):
+    data = {
+        "success": False,
+        "severity": "warning",
+        "issues": [
+            {"message": "bad", "severity": "error", "category": "x"}
+        ],
+    }
+    result = DCR.from_dict(data)
+    assert result.severity == Sev.WARNING
+    assert result.issues[0]["severity"] == Sev.ERROR
+
+
+@pytest.mark.parametrize(
+    "VS",
+    [VisibilitySettings, src_VisibilitySettings],
+)
+def test_visibility_settings_from_dict_parses_string_booleans(VS):
+    settings = VS.from_dict({"readability": "false", "analysis": "True", "version": 1})
+    assert settings.show_readability is False
+    assert settings.show_analysis is True


### PR DESCRIPTION
## Summary
- Allow `DocumentType.from_string` to accept hyphen and underscore separated names
- Parse string severities when deserializing `DocumentCheckResult`
- Handle string boolean values in `VisibilitySettings` and cover new behaviors in tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa63e28d20833281af5d8326c33c69