### PR TITLE
fix: tighten text and link utilities

### DIFF
--- a/govdocverify/utils/link_utils.py
+++ b/govdocverify/utils/link_utils.py
@@ -19,7 +19,7 @@ def find_urls(text: str) -> Iterator[Tuple[str, Tuple[int, int]]]:
     """
 
     _URL_RE = re.compile(
-        r"(?P<url>(?:https?://)?[A-Za-z0-9.-]+\.[A-Za-z]{2,}"
+        r"(?P<url>(?:https?://)?[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?::\d+)?"
         r"(?:/[^\s)]*)?(?:\?[^\s)#]*)?(?:#[^\s)]*)?)",
         re.IGNORECASE,
     )

--- a/govdocverify/utils/security.py
+++ b/govdocverify/utils/security.py
@@ -45,16 +45,20 @@ def sanitize_file_path(file_path: str, base_dir: str | None = None) -> str:
     within that directory; otherwise a :class:`SecurityError` is raised. When
     ``base_dir`` is ``None`` (the default), the path is simply normalized.
     """
-    normalized_path = Path(file_path).expanduser().resolve()
+    path_obj = Path(file_path).expanduser()
 
     if base_dir is not None:
-        base_path = Path(base_dir).resolve()
+        base_path = Path(base_dir).expanduser().resolve()
+        if not path_obj.is_absolute():
+            path_obj = base_path / path_obj
+        normalized_path = path_obj.resolve()
         try:
             normalized_path.relative_to(base_path)
         except ValueError as exc:
             raise SecurityError("Path traversal detected") from exc
+        return str(normalized_path)
 
-    return str(normalized_path)
+    return str(path_obj.resolve())
 
 
 def validate_file(file_path: str) -> None:

--- a/govdocverify/utils/text_utils.py
+++ b/govdocverify/utils/text_utils.py
@@ -209,8 +209,8 @@ def count_words(text: str) -> int:
     emails = list(re.finditer(email_pattern, text))
     email_count = len(emails)
     STOPWORDS = {"to", "or"}
+    word_pattern = r"\b(?:-?\d+(?:\.\d+)?|[\w]+(?:['-][\w]+)*)\b"
     if email_count == 0:
-        word_pattern = r"\b[\w]+(?:['-][\w]+)*\b"
         words = [
             w
             for w in re.findall(word_pattern, text)
@@ -220,7 +220,6 @@ def count_words(text: str) -> int:
         return len(words)
     # Strip e‑mails, count remaining words on both sides, but drop tiny stop‑words
     text_wo_emails = re.sub(email_pattern, " ", text)
-    word_pattern = r"\b[\w]+(?:['-][\w]+)*\b"
     words = [
         w
         for w in re.findall(word_pattern, text_wo_emails)

--- a/src/govdocverify/utils/link_utils.py
+++ b/src/govdocverify/utils/link_utils.py
@@ -18,7 +18,7 @@ def find_urls(text: str) -> Iterator[Tuple[str, Tuple[int, int]]]:
     """
 
     _URL_RE = re.compile(
-        r"(?P<url>(?:https?://)?[A-Za-z0-9.-]+\.[A-Za-z]{2,}"
+        r"(?P<url>(?:https?://)?[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?::\d+)?"
         r"(?:/[^\s)]*)?(?:\?[^\s)#]*)?(?:#[^\s)]*)?)",
         re.IGNORECASE,
     )

--- a/src/govdocverify/utils/security.py
+++ b/src/govdocverify/utils/security.py
@@ -45,16 +45,20 @@ def sanitize_file_path(file_path: str, base_dir: str | None = None) -> str:
     within that directory; otherwise a :class:`SecurityError` is raised. When
     ``base_dir`` is ``None`` (the default), the path is simply normalized.
     """
-    normalized_path = Path(file_path).expanduser().resolve()
+    path_obj = Path(file_path).expanduser()
 
     if base_dir is not None:
-        base_path = Path(base_dir).resolve()
+        base_path = Path(base_dir).expanduser().resolve()
+        if not path_obj.is_absolute():
+            path_obj = base_path / path_obj
+        normalized_path = path_obj.resolve()
         try:
             normalized_path.relative_to(base_path)
         except ValueError as exc:
             raise SecurityError("Path traversal detected") from exc
+        return str(normalized_path)
 
-    return str(normalized_path)
+    return str(path_obj.resolve())
 
 
 def validate_file(file_path: str) -> None:

--- a/src/govdocverify/utils/text_utils.py
+++ b/src/govdocverify/utils/text_utils.py
@@ -206,8 +206,9 @@ def count_words(text: str) -> int:
     emails = list(re.finditer(email_pattern, text))
     email_count = len(emails)
     STOPWORDS = {"to", "or"}
+    word_pattern = r"\b(?:-?\d+(?:\.\d+)?|[\w]+(?:['-][\w]+)*)\b"
+
     if email_count == 0:
-        word_pattern = r"\b[\w]+(?:['-][\w]+)*\b"
         words = [
             w
             for w in re.findall(word_pattern, text)
@@ -217,7 +218,6 @@ def count_words(text: str) -> int:
         return len(words)
     # Strip e‑mails, count remaining words on both sides, but drop tiny stop‑words
     text_wo_emails = re.sub(email_pattern, " ", text)
-    word_pattern = r"\b[\w]+(?:['-][\w]+)*\b"
     words = [
         w
         for w in re.findall(word_pattern, text_wo_emails)

--- a/tests/test_security_utils.py
+++ b/tests/test_security_utils.py
@@ -30,6 +30,15 @@ def test_sanitize_base_dir_enforced(tmp_path: Path) -> None:
         sanitize_file_path(str(outside), base_dir=str(base))
 
 
+def test_sanitize_handles_relative_paths(tmp_path: Path) -> None:
+    base = tmp_path / "base"
+    base.mkdir()
+    (base / "sub").mkdir()
+    rel_path = Path("sub/file.docx")
+    abs_path = (base / rel_path).resolve()
+    assert Path(sanitize_file_path(str(rel_path), base_dir=str(base))) == abs_path
+
+
 @pytest.mark.parametrize("path", ["file.doc", "file.pdf", "file.rtf"])
 def test_validate_source_rejects_legacy_formats(path: str) -> None:
     with pytest.raises(SecurityError, match="Legacy file format"):

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -87,6 +87,11 @@ class TestTextUtils:
         # Multiple spaces
         assert count_words("  multiple   spaces  ") == 2
 
+    def test_count_words_numbers_with_decimals_and_signs(self):
+        """Decimals and signed numbers count as single words."""
+        text = "pi is about 3.14 and temp is -4.5"
+        assert count_words(text) == 8
+
     def test_count_words_contractions(self):
         """Contractions should count as single words."""
         assert count_words("Don't stop") == 2

--- a/tests/test_utils_updates.py
+++ b/tests/test_utils_updates.py
@@ -99,6 +99,12 @@ def test_find_urls_preserves_uppercase_scheme() -> None:
     assert urls == ["HTTPS://Example.gov/"]
 
 
+def test_find_urls_handles_port_numbers() -> None:
+    text = "See http://example.gov:8080/path for details"
+    urls = [u for u, _ in find_urls(text)]
+    assert urls == ["http://example.gov:8080/path"]
+
+
 def test_retry_transient_respects_zero_values(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GOVDOCVERIFY_MAX_RETRIES", "5")
     calls = {"count": 0}


### PR DESCRIPTION
## Summary
- handle relative paths safely in `sanitize_file_path`
- count signed/decimal numbers and detect port numbers in URLs
- add regression tests for text, security and link utilities

## Testing
- `ruff check govdocverify/utils/link_utils.py govdocverify/utils/security.py govdocverify/utils/text_utils.py tests/test_text_utils.py tests/test_security_utils.py tests/test_utils_updates.py`
- `black --check govdocverify/utils/link_utils.py govdocverify/utils/security.py govdocverify/utils/text_utils.py tests/test_text_utils.py tests/test_security_utils.py tests/test_utils_updates.py`
- `mypy --strict govdocverify/utils/link_utils.py govdocverify/utils/security.py govdocverify/utils/text_utils.py tests/test_text_utils.py tests/test_security_utils.py tests/test_utils_updates.py`
- `mypy --strict tests/test_text_utils.py`
- `bandit -r src -lll --skip B101` *(fails: command not found)*
- `semgrep --config p/ci` *(fails: command not found)*
- `pytest -q`
- `python -m trace --count --summary --ignore-dir=/usr --ignore-dir=/root/.pyenv --module pytest -- -q`

------
https://chatgpt.com/codex/tasks/task_e_68aae6f192548332bbb1412fafd0d35b