### PR TITLE
fix(utils): handle complex urls and enforce extensions

### DIFF
--- a/govdocverify/utils/link_utils.py
+++ b/govdocverify/utils/link_utils.py
@@ -20,14 +20,32 @@ def find_urls(text: str) -> Iterator[Tuple[str, Tuple[int, int]]]:
 
     _URL_RE = re.compile(
         r"(?P<url>(?:https?://)?[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?::\d+)?"
-        r"(?:/[^\s)]*)?(?:\?[^\s)#]*)?(?:#[^\s)]*)?)",
+        r"(?:/[^\s]*)?(?:\?[^\s]*)?(?:#[^\s]*)?)",
         re.IGNORECASE,
     )
+
+    def _strip_trailing(url: str) -> str:
+        punctuation = ".,;:!?"
+        brackets = {")": "(", "]": "[", "}": "{", "'": "'", '"': '"'}
+        while url:
+            last = url[-1]
+            if last in punctuation:
+                url = url[:-1]
+                continue
+            if last in brackets:
+                opener = brackets[last]
+                if url.count(last) > url.count(opener):
+                    url = url[:-1]
+                    continue
+            break
+        return url
+
     for line_no, line in enumerate(text.splitlines(), 1):
         for m in _URL_RE.finditer(line):
-            # Strip common trailing punctuation so callers don't need to handle
-            # cases like ``"https://example.gov/test."`` themselves.
-            url = m.group("url").rstrip(".,;:!?)[]}'\"")
+            # Strip trailing punctuation or unmatched closing brackets so
+            # callers don't need to handle cases like
+            # ``"https://example.gov/test)."`` themselves.
+            url = _strip_trailing(m.group("url"))
             yield url, (line_no, m.start())
 
 
@@ -36,8 +54,9 @@ def normalise(url: str) -> str:
     scheme_url = url if url.lower().startswith("http") else f"//{url}"
     parsed = urllib.parse.urlparse(scheme_url, scheme="https")
     host = parsed.hostname.lower().rstrip(".") if parsed.hostname else ""
+    port = f":{parsed.port}" if parsed.port else ""
     path = parsed.path.rstrip("/").rstrip(".,;:!?")
-    return f"{host}{path}" if path else host
+    return f"{host}{port}{path}" if path else f"{host}{port}"
 
 
 def deprecated_lookup(url: str) -> Optional[str]:

--- a/govdocverify/utils/security.py
+++ b/govdocverify/utils/security.py
@@ -176,7 +176,9 @@ def validate_source(path: str) -> None:
     parsed = urlparse(lowered)
     _, ext = os.path.splitext(parsed.path)
 
-    if "://" not in lowered and not ext:
+    # Allow bare local paths without an extension and without any additional
+    # URL components.  Anything else must include a file extension.
+    if not parsed.scheme and not ext and not parsed.query and not parsed.fragment:
         return
     if not ext:
         raise SecurityError("Missing file extension")

--- a/src/govdocverify/utils/security.py
+++ b/src/govdocverify/utils/security.py
@@ -172,7 +172,9 @@ def validate_source(path: str) -> None:
     parsed = urlparse(lowered)
     _, ext = os.path.splitext(parsed.path)
 
-    if "://" not in lowered and not ext:
+    # Permit bare local paths without extension or URL components.  All other
+    # forms must include an extension for validation.
+    if not parsed.scheme and not ext and not parsed.query and not parsed.fragment:
         return
     if not ext:
         raise SecurityError("Missing file extension")

--- a/tests/test_security_utils.py
+++ b/tests/test_security_utils.py
@@ -52,3 +52,8 @@ def test_validate_source_rejects_legacy_formats(path: str) -> None:
 def test_validate_source_handles_uppercase_schemes(url: str) -> None:
     with pytest.raises(SecurityError, match="Non-government"):
         validate_source(url)
+
+
+def test_validate_source_requires_extension_with_query() -> None:
+    with pytest.raises(SecurityError, match="Missing file extension"):
+        validate_source("file?download=1")

--- a/tests/test_utils_updates.py
+++ b/tests/test_utils_updates.py
@@ -105,6 +105,12 @@ def test_find_urls_handles_port_numbers() -> None:
     assert urls == ["http://example.gov:8080/path"]
 
 
+def test_find_urls_handles_parentheses_in_url() -> None:
+    text = "More info at https://example.gov/path_(test)."
+    urls = [u for u, _ in find_urls(text)]
+    assert urls == ["https://example.gov/path_(test)"]
+
+
 def test_retry_transient_respects_zero_values(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GOVDOCVERIFY_MAX_RETRIES", "5")
     calls = {"count": 0}
@@ -132,3 +138,7 @@ def test_validate_source_allows_query_and_fragment(url: str) -> None:
 
 def test_validate_source_allows_trailing_dot_domain() -> None:
     validate_source("https://agency.gov./file.docx")
+
+
+def test_normalise_preserves_port() -> None:
+    assert normalise("https://Example.gov:8000/path/") == "example.gov:8000/path"


### PR DESCRIPTION
## Summary
- improve URL parsing to retain ports and balanced parentheses
- tighten source validation to require extensions when queries present
- add tests for complex URLs and security edge cases

## Testing
- `ruff check govdocverify src tests`
- `black --check govdocverify/utils/link_utils.py govdocverify/utils/security.py src/govdocverify/utils/link_utils.py src/govdocverify/utils/security.py tests/test_utils_updates.py tests/test_security_utils.py`
- `mypy govdocverify/utils/link_utils.py govdocverify/utils/security.py tests/test_utils_updates.py tests/test_security_utils.py --ignore-missing-imports`
- `pytest -q`
- `python -m trace --count --summary --ignore-dir=/root/.pyenv --ignore-dir=/usr --ignore-dir=/lib --module pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab7c5c724c8332b0927f5e82e7f3f0