### PR TITLE
Fix scheme validation, word counting, and list formatting

### DIFF
--- a/govdocverify/formatting/document_formatter.py
+++ b/govdocverify/formatting/document_formatter.py
@@ -31,11 +31,12 @@ class DocumentFormatter:
             # Format section symbols
             line = self._format_section_symbols(line)
 
+            # Remove extra spaces before applying list formatting so added
+            # indentation isn't stripped away
+            line = re.sub(r"\s+", " ", line).strip()
+
             # Format lists
             line = self._format_lists(line)
-
-            # Remove extra spaces
-            line = re.sub(r"\s+", " ", line).strip()
 
             formatted_lines.append(line)
 

--- a/govdocverify/utils/security.py
+++ b/govdocverify/utils/security.py
@@ -187,6 +187,9 @@ def validate_source(path: str) -> None:
     if ext not in ALLOWED_FILE_EXTENSIONS:
         raise SecurityError(f"Disallowed file format: {ext}")
 
+    if parsed.scheme and parsed.scheme not in {"http", "https"}:
+        raise SecurityError(f"Unsupported URL scheme: {parsed.scheme}")
+
     if parsed.scheme in {"http", "https"}:
         domain = parsed.hostname or ""
         if not _is_allowed_domain(domain):

--- a/govdocverify/utils/text_utils.py
+++ b/govdocverify/utils/text_utils.py
@@ -205,11 +205,13 @@ def count_words(text: str) -> int:
     if not text:
         logger.debug("count_words: empty input -> 0")
         return 0
+    # Treat underscores as spaces so ``snake_case`` counts as two words.
+    text = text.replace("_", " ")
     email_pattern = r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"
     emails = list(re.finditer(email_pattern, text))
     email_count = len(emails)
     STOPWORDS = {"to", "or"}
-    word_pattern = r"\b(?:-?\d+(?:\.\d+)?|[\w]+(?:['-][\w]+)*)\b"
+    word_pattern = r"\b(?:-?\d+(?:\.\d+)?|[A-Za-z0-9]+(?:['-][A-Za-z0-9]+)*)\b"
     if email_count == 0:
         words = [
             w

--- a/src/govdocverify/formatting/document_formatter.py
+++ b/src/govdocverify/formatting/document_formatter.py
@@ -31,11 +31,12 @@ class DocumentFormatter:
             # Format section symbols
             line = self._format_section_symbols(line)
 
+            # Remove extra spaces before handling lists so indentation added
+            # later isn't stripped away
+            line = re.sub(r"\s+", " ", line).strip()
+
             # Format lists
             line = self._format_lists(line)
-
-            # Remove extra spaces
-            line = re.sub(r"\s+", " ", line).strip()
 
             formatted_lines.append(line)
 

--- a/src/govdocverify/utils/security.py
+++ b/src/govdocverify/utils/security.py
@@ -183,6 +183,9 @@ def validate_source(path: str) -> None:
     if ext not in ALLOWED_FILE_EXTENSIONS:
         raise SecurityError(f"Disallowed file format: {ext}")
 
+    if parsed.scheme and parsed.scheme not in {"http", "https"}:
+        raise SecurityError(f"Unsupported URL scheme: {parsed.scheme}")
+
     if parsed.scheme in {"http", "https"}:
         domain = parsed.hostname or ""
         if not _is_allowed_domain(domain):

--- a/src/govdocverify/utils/text_utils.py
+++ b/src/govdocverify/utils/text_utils.py
@@ -202,11 +202,15 @@ def count_words(text: str) -> int:
     if not text:
         logger.debug("count_words: empty input -> 0")
         return 0
+    # Treat underscores as spaces so ``snake_case`` counts as two words.
+    text = text.replace("_", " ")
     email_pattern = r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"
     emails = list(re.finditer(email_pattern, text))
     email_count = len(emails)
     STOPWORDS = {"to", "or"}
-    word_pattern = r"\b(?:-?\d+(?:\.\d+)?|[\w]+(?:['-][\w]+)*)\b"
+    # Use an explicit character class that excludes underscores to split tokens
+    # like ``snake_case`` into separate words.
+    word_pattern = r"\b(?:-?\d+(?:\.\d+)?|[A-Za-z0-9]+(?:['-][A-Za-z0-9]+)*)\b"
 
     if email_count == 0:
         words = [

--- a/tests/test_document_formatter.py
+++ b/tests/test_document_formatter.py
@@ -7,7 +7,8 @@ def test_format_text_basic():
     formatted = formatter.format_text(text)
     assert '"hello"' in formatted
     assert "\u00a7 1" in formatted
-    assert formatted.splitlines()[1] == "item"
+    # List items should retain indentation after formatting
+    assert formatted.splitlines()[1] == "    item"
 
 
 def test_check_formatting_issues():

--- a/tests/test_security_utils.py
+++ b/tests/test_security_utils.py
@@ -57,3 +57,9 @@ def test_validate_source_handles_uppercase_schemes(url: str) -> None:
 def test_validate_source_requires_extension_with_query() -> None:
     with pytest.raises(SecurityError, match="Missing file extension"):
         validate_source("file?download=1")
+
+
+def test_validate_source_rejects_unsupported_scheme() -> None:
+    """Non-HTTP schemes like FTP should be rejected explicitly."""
+    with pytest.raises(SecurityError, match="Unsupported URL scheme"):
+        validate_source("ftp://example.gov/file.docx")

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -97,6 +97,11 @@ class TestTextUtils:
         assert count_words("Don't stop") == 2
         assert count_words("We're testing") == 2
 
+    def test_count_words_splits_on_underscores(self):
+        """Underscores should act as word separators."""
+        assert count_words("snake_case") == 2
+        assert count_words("mixed_snake_case example") == 4
+
     def test_normalize_reference(self):
         """Test reference normalization."""
         # Empty text


### PR DESCRIPTION
## Summary
- validate_source now rejects unsupported URL schemes
- count_words treats underscores as separators for accurate word counts
- DocumentFormatter preserves indentation for list items
- added tests for new behaviours and rejecting unsupported schemes

## Testing
- `pytest tests -q --disable-warnings`
- `python -m trace --count --summary --coverdir=trace_small --ignore-dir=/root/.pyenv/versions/3.12.10/lib --module pytest tests/test_security_utils.py tests/test_text_utils.py tests/test_document_formatter.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab802324b4833292dd3a4e73f652dd