### PR TITLE
Improve word counting and source validation

### DIFF
--- a/govdocverify/formatting/document_formatter.py
+++ b/govdocverify/formatting/document_formatter.py
@@ -96,8 +96,11 @@ class DocumentFormatter:
         """
         issues = []
 
-        # Check for inconsistent quotation marks
-        if "'" in text and '"' in text:
+        # Check for inconsistent quotation marks.  A single quote can also be
+        # used as an apostrophe (e.g. "it's"), so only flag a mixture when a
+        # standalone single-quoted string is present alongside double quotes.
+        single_quoted = re.search(r"(^|\W)'[^']+'", text)
+        if single_quoted and '"' in text:
             issues.append(
                 {
                     "type": "formatting",

--- a/govdocverify/utils/text_utils.py
+++ b/govdocverify/utils/text_utils.py
@@ -210,22 +210,18 @@ def count_words(text: str) -> int:
     email_pattern = r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"
     emails = list(re.finditer(email_pattern, text))
     email_count = len(emails)
-    STOPWORDS = {"to", "or"}
     word_pattern = r"\b(?:-?\d+(?:\.\d+)?|[A-Za-z0-9]+(?:['-][A-Za-z0-9]+)*)\b"
+
     if email_count == 0:
-        words = [
-            w
-            for w in re.findall(word_pattern, text)
-            if re.search(r"[a-zA-Z0-9]", w) and w.lower() not in STOPWORDS
-        ]
-        logger.debug(f"count_words: input='{text}' emails=0 words={words} total={len(words)}")
+        words = [w for w in re.findall(word_pattern, text) if re.search(r"[a-zA-Z0-9]", w)]
+        logger.debug(
+            f"count_words: input='{text}' emails=0 words={words} total={len(words)}"
+        )
         return len(words)
-    # Strip e‑mails, count remaining words on both sides, but drop tiny stop‑words
+
     text_wo_emails = re.sub(email_pattern, " ", text)
     words = [
-        w
-        for w in re.findall(word_pattern, text_wo_emails)
-        if re.search(r"[a-zA-Z0-9]", w) and w.lower() not in STOPWORDS
+        w for w in re.findall(word_pattern, text_wo_emails) if re.search(r"[a-zA-Z0-9]", w)
     ]
     logger.debug(
         f"count_words: input='{text}', "

--- a/tests/test_document_formatter.py
+++ b/tests/test_document_formatter.py
@@ -20,3 +20,11 @@ def test_check_formatting_issues():
     assert any("Mixed quotation marks" in m for m in msgs)
     assert any("section symbol" in m for m in msgs)
     assert len(msgs) == 2
+
+
+def test_check_formatting_ignores_apostrophes():
+    formatter = DocumentFormatter()
+    text = "It's a \"quote\""
+    result = formatter.check_formatting(text)
+    assert result.success
+    assert all("Mixed quotation" not in i["message"] for i in result.issues)

--- a/tests/test_security_utils.py
+++ b/tests/test_security_utils.py
@@ -63,3 +63,8 @@ def test_validate_source_rejects_unsupported_scheme() -> None:
     """Non-HTTP schemes like FTP should be rejected explicitly."""
     with pytest.raises(SecurityError, match="Unsupported URL scheme"):
         validate_source("ftp://example.gov/file.docx")
+
+
+def test_validate_source_accepts_windows_paths() -> None:
+    """Windows-style absolute paths should be treated as local files."""
+    validate_source("C:\\gov\\docs\\file.docx")

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -82,7 +82,7 @@ class TestTextUtils:
 
         # Email addresses
         assert count_words("test@example.com") == 1
-        assert count_words("Send to test@example.com today") == 3
+        assert count_words("Send to test@example.com today") == 4
 
         # Multiple spaces
         assert count_words("  multiple   spaces  ") == 2
@@ -101,6 +101,10 @@ class TestTextUtils:
         """Underscores should act as word separators."""
         assert count_words("snake_case") == 2
         assert count_words("mixed_snake_case example") == 4
+
+    def test_count_words_includes_common_stopwords(self):
+        """Previously excluded words like 'to' and 'or' should be counted."""
+        assert count_words("to be or not to be") == 6
 
     def test_normalize_reference(self):
         """Test reference normalization."""
@@ -260,7 +264,7 @@ class TestTextUtils:
         """Test word counting with complex email scenarios."""
         # Multiple email addresses
         text = "Contact user@example.com or admin@test.com today"
-        assert count_words(text) == 4  # 2 emails + 'or' + 'today'
+        assert count_words(text) == 5  # Contact + 2 emails + 'or' + 'today'
 
         # Email with hyphenation
         text = "my-email@example.com is well-known"


### PR DESCRIPTION
## Summary
- fix `count_words` to count common words and handle emails accurately
- avoid false mixed-quote warnings in `DocumentFormatter`
- validate Windows-style paths in `validate_source`
- add tests for new behaviors

## Testing
- `pytest -q --disable-warnings`
- `python -m trace --count --summary --coverdir=tracecov /tmp/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab849755588332a3d32f7b9a8476be