### PR TITLE
Fix spelling in plugin test pragma comment

### DIFF
--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -16,7 +16,7 @@ class GoodPlugin(Plugin):
     def name(self) -> str:
         return "good"
 
-    def register(self) -> None:  # pragma: no cover - no behaviour
+    def register(self) -> None:  # pragma: no cover - no behavior
         pass
 
 


### PR DESCRIPTION
## Summary
- fix spelling of behavior in test plugin's pragma comment

## Testing
- `pytest tests/test_plugins.py`

------
https://chatgpt.com/codex/tasks/task_e_68b76f0830a483329c1939d0ee8b4112