### PR TITLE
chore: use American English spelling

### DIFF
--- a/src/govdocverify/utils/__init__.py
+++ b/src/govdocverify/utils/__init__.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 __all__: list[str] = ["extract_docx_metadata"]
 
-# Static analysers / IDEs see the symbol without importing heavy deps
+# Static analyzers / IDEs see the symbol without importing heavy deps
 if TYPE_CHECKING:  # pragma: no cover
     from .metadata_utils import extract_docx_metadata
 


### PR DESCRIPTION
## Summary
- replace British spelling "analysers" with "analyzers" in utilities module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b76fb33448833282f9cfacc64cc623