### PR TITLE
Standardize analyzer spelling in utils

### DIFF
--- a/govdocverify/utils/__init__.py
+++ b/govdocverify/utils/__init__.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 
 __all__: list[str] = ["extract_docx_metadata"]
 
-# Allow static analysers / IDEs to see the symbol without importing heavy deps
+# Allow static analyzers / IDEs to see the symbol without importing heavy deps
 if TYPE_CHECKING:  # pragma: no cover
     from .metadata_utils import extract_docx_metadata
 


### PR DESCRIPTION
## Summary
- replace 'analysers' with 'analyzers' in utils module comment

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b78be111f883329b27a60668a7e968