### PR TITLE
chore: use American English spelling

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -58,7 +58,7 @@ tests-mypy = ["mypy (>=1.11.1) ; platform_python_implementation == \"CPython\" a
 [[package]]
 name = "bandit"
 version = "1.8.6"
-description = "Security oriented static analyser for python code."
+description = "Security oriented static analyzer for python code."
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]


### PR DESCRIPTION
## Summary
- replace British English spelling in poetry.lock with American spelling

## Testing
- `pre-commit run --all-files` *(fails: command not found; `pip install pre-commit` blocked by 403 Forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b79aee66c48332928aedf60b8c7f99