### PR TITLE
Fix retry backoff defaults and URL normalization

### DIFF
--- a/govdocverify/utils/decorators.py
+++ b/govdocverify/utils/decorators.py
@@ -37,9 +37,15 @@ def retry_transient(
     """
 
     if max_attempts is None:
-        max_attempts = int(os.getenv("GOVDOCVERIFY_MAX_RETRIES", "3"))
+        try:
+            max_attempts = int(os.getenv("GOVDOCVERIFY_MAX_RETRIES", "3"))
+        except ValueError:
+            max_attempts = 3
     if backoff is None:
-        backoff = float(os.getenv("GOVDOCVERIFY_BACKOFF", "0.1"))
+        try:
+            backoff = float(os.getenv("GOVDOCVERIFY_BACKOFF", "0.1"))
+        except ValueError:
+            backoff = 0.1
 
     def decorator(func: F) -> F:
         return cast(

--- a/govdocverify/utils/link_utils.py
+++ b/govdocverify/utils/link_utils.py
@@ -62,7 +62,12 @@ def normalise(url: str) -> str:
     scheme_url = url if url.lower().startswith("http") else f"//{url}"
     parsed = urllib.parse.urlparse(scheme_url, scheme="https")
     host = parsed.hostname.lower().rstrip(".") if parsed.hostname else ""
-    port = f":{parsed.port}" if parsed.port else ""
+    port = ""
+    if parsed.port and not (
+        (parsed.scheme == "http" and parsed.port == 80)
+        or (parsed.scheme == "https" and parsed.port == 443)
+    ):
+        port = f":{parsed.port}"
     path = parsed.path.rstrip("/").rstrip(".,;:!?")
     return f"{host}{port}{path}" if path else f"{host}{port}"
 

--- a/govdocverify/utils/text_utils.py
+++ b/govdocverify/utils/text_utils.py
@@ -244,8 +244,8 @@ def normalize_reference(text: str) -> str:
     # Convert to lowercase
     text = text.lower()
 
-    # Replace special characters with spaces
-    text = re.sub(r"[^\w\s]", " ", text)
+    # Replace special characters (including underscores) with spaces
+    text = re.sub(r"[\W_]+", " ", text)
 
     # Normalize whitespace
     text = re.sub(r"\s+", " ", text)

--- a/src/govdocverify/utils/decorators.py
+++ b/src/govdocverify/utils/decorators.py
@@ -37,9 +37,15 @@ def retry_transient(
     """
 
     if max_attempts is None:
-        max_attempts = int(os.getenv("GOVDOCVERIFY_MAX_RETRIES", "3"))
+        try:
+            max_attempts = int(os.getenv("GOVDOCVERIFY_MAX_RETRIES", "3"))
+        except ValueError:
+            max_attempts = 3
     if backoff is None:
-        backoff = float(os.getenv("GOVDOCVERIFY_BACKOFF", "0.1"))
+        try:
+            backoff = float(os.getenv("GOVDOCVERIFY_BACKOFF", "0.1"))
+        except ValueError:
+            backoff = 0.1
 
     def decorator(func: F) -> F:
         return cast(

--- a/src/govdocverify/utils/link_utils.py
+++ b/src/govdocverify/utils/link_utils.py
@@ -63,7 +63,12 @@ def normalise(url: str) -> str:
     scheme_url = url if url.lower().startswith("http") else f"//{url}"
     parsed = urllib.parse.urlparse(scheme_url, scheme="https")
     host = parsed.hostname.lower().rstrip(".") if parsed.hostname else ""
-    port = f":{parsed.port}" if parsed.port else ""
+    port = ""
+    if parsed.port and not (
+        (parsed.scheme == "http" and parsed.port == 80)
+        or (parsed.scheme == "https" and parsed.port == 443)
+    ):
+        port = f":{parsed.port}"
     path = parsed.path.rstrip("/").rstrip(".,;:!?")
     return f"{host}{port}{path}" if path else f"{host}{port}"
 

--- a/src/govdocverify/utils/text_utils.py
+++ b/src/govdocverify/utils/text_utils.py
@@ -248,8 +248,8 @@ def normalize_reference(text: str) -> str:
     # Convert to lowercase
     text = text.lower()
 
-    # Replace special characters with spaces
-    text = re.sub(r"[^\w\s]", " ", text)
+    # Replace special characters (including underscores) with spaces
+    text = re.sub(r"[\W_]+", " ", text)
 
     # Normalize whitespace
     text = re.sub(r"\s+", " ", text)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,7 +1,9 @@
 import logging
 import time
 
-from govdocverify.utils.decorators import profile_performance
+import pytest
+
+from govdocverify.utils.decorators import profile_performance, retry_transient
 
 
 def test_profile_performance(caplog):
@@ -15,3 +17,24 @@ def test_profile_performance(caplog):
 
     assert result == 6
     assert any("sample took" in record.message for record in caplog.records)
+
+
+def test_retry_transient_defaults_on_invalid_env(monkeypatch):
+    """Invalid environment variables should fall back to safe defaults."""
+
+    # Provide non-numeric values that would previously raise ``ValueError``
+    monkeypatch.setenv("GOVDOCVERIFY_MAX_RETRIES", "not-int")
+    monkeypatch.setenv("GOVDOCVERIFY_BACKOFF", "bad")
+
+    calls = {"count": 0}
+
+    @retry_transient()
+    def boom() -> None:
+        calls["count"] += 1
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError):
+        boom()
+
+    # Should retry the default number of times (3 attempts total)
+    assert calls["count"] == 3

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -118,6 +118,10 @@ class TestTextUtils:
         # Special characters
         assert normalize_reference("Test-Reference!") == "test reference"
         assert normalize_reference("Test & Reference") == "test reference"
+
+    def test_normalize_reference_replaces_underscores(self):
+        """Underscores should be treated as word separators."""
+        assert normalize_reference("Example_With_Underscores") == "example with underscores"
         assert normalize_reference("Test/Reference\\Path") == "test reference path"
 
     def test_count_syllables(self):

--- a/tests/test_utils_updates.py
+++ b/tests/test_utils_updates.py
@@ -142,3 +142,9 @@ def test_validate_source_allows_trailing_dot_domain() -> None:
 
 def test_normalise_preserves_port() -> None:
     assert normalise("https://Example.gov:8000/path/") == "example.gov:8000/path"
+
+
+def test_normalise_strips_default_ports() -> None:
+    """Default HTTP/HTTPS ports should not appear in normalised output."""
+    assert normalise("http://Example.gov:80/path/") == "example.gov/path"
+    assert normalise("https://Example.gov:443/path/") == "example.gov/path"


### PR DESCRIPTION
## Summary
- handle invalid GOVDOCVERIFY_MAX_RETRIES/BACKOFF values in `retry_transient`
- normalize references by treating underscores as separators
- strip default HTTP/HTTPS ports in URL normalization and add regression tests

## Testing
- `pytest -q`
- `python -m trace --count --summary --ignore-dir=/root/.pyenv/versions/3.12.10/lib/python3.12 --ignore-dir=/root/.pyenv/versions/3.12.10/lib/python3.12/site-packages --ignore-dir=tests --ignore-dir=node_modules /root/.pyenv/versions/3.12.10/bin/pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bac278fcf08332a2c7eedc73d271d5