### PR TITLE
Improve reliability and encoding handling

### DIFF
--- a/govdocverify/utils/network.py
+++ b/govdocverify/utils/network.py
@@ -1,20 +1,31 @@
 """HTTP helpers with retry support."""
-
 from __future__ import annotations
+
+import os
 
 import httpx
 
 from govdocverify.utils.decorators import retry_transient
 
+DEFAULT_TIMEOUT = float(os.getenv("GOVDOCVERIFY_HTTP_TIMEOUT", "5"))
+
 
 @retry_transient()
-def fetch_url(url: str) -> str:
+def fetch_url(url: str, timeout: float = DEFAULT_TIMEOUT) -> str:
     """Return the text content from ``url``.
 
     Requests are retried on transient failures according to configuration
     provided via environment variables.
+
+    Parameters
+    ----------
+    url: str
+        The URL to fetch.
+    timeout: float
+        Timeout in seconds for the request. Defaults to ``DEFAULT_TIMEOUT`` and
+        may be overridden via ``GOVDOCVERIFY_HTTP_TIMEOUT``.
     """
 
-    response = httpx.get(url)
+    response = httpx.get(url, timeout=timeout)
     response.raise_for_status()
     return response.text

--- a/src/govdocverify/export.py
+++ b/src/govdocverify/export.py
@@ -17,7 +17,7 @@ def save_results_as_docx(results: dict[str, Any], path: str) -> None:
     """Save results as a DOCX file."""
     doc = Document()
     doc.add_heading("Document Check Results", level=1)
-    doc.add_paragraph(json.dumps(results, indent=2))
+    doc.add_paragraph(json.dumps(results, indent=2, ensure_ascii=False))
     doc.save(path)
 
 
@@ -31,6 +31,6 @@ def save_results_as_pdf(results: dict[str, Any], path: str) -> None:
     pdf = FPDF()
     pdf.add_page()
     pdf.set_font("Helvetica", size=12)
-    for line in json.dumps(results, indent=2).splitlines():
+    for line in json.dumps(results, indent=2, ensure_ascii=False).splitlines():
         pdf.cell(0, 10, txt=line, ln=True)
     pdf.output(path)

--- a/src/govdocverify/utils/network.py
+++ b/src/govdocverify/utils/network.py
@@ -1,20 +1,31 @@
 """HTTP helpers with retry support."""
-
 from __future__ import annotations
+
+import os
 
 import httpx
 
 from govdocverify.utils.decorators import retry_transient
 
+DEFAULT_TIMEOUT = float(os.getenv("GOVDOCVERIFY_HTTP_TIMEOUT", "5"))
+
 
 @retry_transient()
-def fetch_url(url: str) -> str:
+def fetch_url(url: str, timeout: float = DEFAULT_TIMEOUT) -> str:
     """Return the text content from ``url``.
 
     Requests are retried on transient failures according to configuration
     provided via environment variables.
+
+    Parameters
+    ----------
+    url: str
+        The URL to fetch.
+    timeout: float
+        Timeout in seconds for the request. Defaults to ``DEFAULT_TIMEOUT`` and
+        may be overridden via ``GOVDOCVERIFY_HTTP_TIMEOUT``.
     """
 
-    response = httpx.get(url)
+    response = httpx.get(url, timeout=timeout)
     response.raise_for_status()
     return response.text

--- a/tests/test_export_unicode.py
+++ b/tests/test_export_unicode.py
@@ -1,0 +1,20 @@
+import importlib.util
+import pathlib
+import zipfile
+
+
+def load_src_export():
+    module_path = pathlib.Path('src/govdocverify/export.py')
+    spec = importlib.util.spec_from_file_location('export_src', module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_save_results_docx_handles_unicode(tmp_path):
+    export = load_src_export()
+    path = tmp_path / 'result.docx'
+    export.save_results_as_docx({'text': 'café'}, str(path))
+    with zipfile.ZipFile(path) as zf:
+        xml = zf.read('word/document.xml').decode('utf-8')
+    assert 'café' in xml

--- a/tests/test_network_timeout.py
+++ b/tests/test_network_timeout.py
@@ -1,0 +1,17 @@
+from govdocverify.utils import network
+
+
+def test_fetch_url_uses_timeout(monkeypatch):
+    called = {}
+
+    def fake_get(url, timeout):
+        called['timeout'] = timeout
+        class Resp:
+            text = 'ok'
+            def raise_for_status(self):
+                pass
+        return Resp()
+
+    monkeypatch.setattr(network.httpx, 'get', fake_get)
+    assert network.fetch_url('http://example.com') == 'ok'
+    assert called['timeout'] == network.DEFAULT_TIMEOUT

--- a/tests/test_processing_read_file.py
+++ b/tests/test_processing_read_file.py
@@ -1,0 +1,7 @@
+from govdocverify.processing import _read_file_content
+
+
+def test_read_file_content_latin1(tmp_path):
+    path = tmp_path / 'latin1.txt'
+    path.write_bytes('café'.encode('latin-1'))
+    assert _read_file_content(str(path)) == 'café'

--- a/tests/test_reliability.py
+++ b/tests/test_reliability.py
@@ -20,7 +20,7 @@ def test_retry_transient_failures(monkeypatch: pytest.MonkeyPatch) -> None:
 
     attempts = {"count": 0}
 
-    def flaky_get(url: str) -> httpx.Response:
+    def flaky_get(url: str, **_: object) -> httpx.Response:
         attempts["count"] += 1
         raise httpx.RequestError("boom", request=httpx.Request("GET", url))
 
@@ -93,7 +93,7 @@ def test_graceful_shutdown_under_load(tmp_path: Path) -> None:
 
     async def _hammer() -> list[httpx.Response]:
         async with httpx.AsyncClient() as client:
-            tasks = [client.get(f"{base_url}/slow") for _ in range(5)]
+            tasks = [asyncio.create_task(client.get(f"{base_url}/slow")) for _ in range(5)]
             await asyncio.sleep(0.1)
             os.kill(proc.pid, signal.SIGTERM)
             return await asyncio.gather(*tasks)


### PR DESCRIPTION
## Summary
- ensure fetch_url applies a timeout and tests it
- preserve unicode characters when exporting results
- stabilize server shutdown test and add coverage for file/encoding utilities

## Testing
- `python -m pytest -q`
- `python -m trace --report --summary --file=trace.log | head`


------
https://chatgpt.com/codex/tasks/task_e_68bae199db3c8332bf66bb90dab5c36a