### PR TITLE
fix(utils): improve text analysis edge cases

### DIFF
--- a/govdocverify/utils/text_utils.py
+++ b/govdocverify/utils/text_utils.py
@@ -210,7 +210,7 @@ def count_words(text: str) -> int:
     email_pattern = r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"
     emails = list(re.finditer(email_pattern, text))
     email_count = len(emails)
-    word_pattern = r"\b(?:-?\d+(?:\.\d+)?|[A-Za-z0-9]+(?:['-][A-Za-z0-9]+)*)\b"
+    word_pattern = r"\b(?:-?\d{1,3}(?:,\d{3})*(?:\.\d+)?|[A-Za-z0-9]+(?:['-][A-Za-z0-9]+)*)\b"
 
     if email_count == 0:
         words = [w for w in re.findall(word_pattern, text) if re.search(r"[a-zA-Z0-9]", w)]
@@ -260,9 +260,10 @@ def count_syllables(word: str) -> int:
     if not word:
         logger.debug("count_syllables: empty input -> 0")
         return 0
-    if word.isdigit():
-        logger.debug(f"count_syllables: digits '{word}' -> {len(word)}")
-        return len(word)
+    if any(ch.isdigit() for ch in word) and re.fullmatch(r"[\d,\.]+", word):
+        digits = re.sub(r"\D", "", word)
+        logger.debug(f"count_syllables: digits '{word}' -> {len(digits)}")
+        return len(digits)
     # Special-case known acronyms with non-standard syllable counts
     acronym_special = {"GUI": 2}
     if len(word) <= 3 and word.isupper():
@@ -385,6 +386,7 @@ def calculate_passive_voice_percentage(text: str) -> float:
     passive_patterns = [
         r"\b(?:am|is|are|was|were|be|been|being)\s+\w+(?:ed|en|wn)\s+by\b",
         r"\b(?:has|have|had)\s+been\s+\w+(?:ed|en|wn)\b",
+        r"\b(?:am|is|are|was|were|be|been|being)\s+\w{4,}(?:ed|en|wn)\b",
     ]
     passive_regex = re.compile("|".join(passive_patterns), re.IGNORECASE)
     passive_count = sum(1 for sentence in sentences if passive_regex.search(sentence))

--- a/src/govdocverify/utils/text_utils.py
+++ b/src/govdocverify/utils/text_utils.py
@@ -210,7 +210,7 @@ def count_words(text: str) -> int:
     STOPWORDS = {"to", "or"}
     # Use an explicit character class that excludes underscores to split tokens
     # like ``snake_case`` into separate words.
-    word_pattern = r"\b(?:-?\d+(?:\.\d+)?|[A-Za-z0-9]+(?:['-][A-Za-z0-9]+)*)\b"
+    word_pattern = r"\b(?:-?\d{1,3}(?:,\d{3})*(?:\.\d+)?|[A-Za-z0-9]+(?:['-][A-Za-z0-9]+)*)\b"
 
     if email_count == 0:
         words = [
@@ -264,9 +264,10 @@ def count_syllables(word: str) -> int:
     if not word:
         logger.debug("count_syllables: empty input -> 0")
         return 0
-    if word.isdigit():
-        logger.debug(f"count_syllables: digits '{word}' -> {len(word)}")
-        return len(word)
+    if any(ch.isdigit() for ch in word) and re.fullmatch(r"[\d,\.]+", word):
+        digits = re.sub(r"\D", "", word)
+        logger.debug(f"count_syllables: digits '{word}' -> {len(digits)}")
+        return len(digits)
     # Special-case known acronyms with non-standard syllable counts
     acronym_special = {"GUI": 2}
     if len(word) <= 3 and word.isupper():
@@ -389,6 +390,7 @@ def calculate_passive_voice_percentage(text: str) -> float:
     passive_patterns = [
         r"\b(?:am|is|are|was|were|be|been|being)\s+\w+(?:ed|en|wn)\s+by\b",
         r"\b(?:has|have|had)\s+been\s+\w+(?:ed|en|wn)\b",
+        r"\b(?:am|is|are|was|were|be|been|being)\s+\w{4,}(?:ed|en|wn)\b",
     ]
     passive_regex = re.compile("|".join(passive_patterns), re.IGNORECASE)
     passive_count = sum(1 for sentence in sentences if passive_regex.search(sentence))

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -92,6 +92,10 @@ class TestTextUtils:
         text = "pi is about 3.14 and temp is -4.5"
         assert count_words(text) == 8
 
+    def test_count_words_handles_commas_in_numbers(self):
+        """Numbers containing thousands separators count as one word."""
+        assert count_words("The value is 1,234 and 5,678.9") == 6
+
     def test_count_words_contractions(self):
         """Contractions should count as single words."""
         assert count_words("Don't stop") == 2
@@ -194,6 +198,11 @@ class TestTextUtils:
     def test_calculate_passive_voice_percentage_ignores_adjectives(self):
         """Simple "is" + adjective should not be flagged."""
         assert calculate_passive_voice_percentage("The car is red.") == 0.0
+
+    def test_calculate_passive_voice_percentage_without_by(self):
+        """Sentences in passive voice without an explicit agent are detected."""
+        text = "The report was completed. The team reviewed it."
+        assert calculate_passive_voice_percentage(text) == 50.0
 
     def test_extract_acronyms(self):
         """Test acronym extraction."""
@@ -322,6 +331,11 @@ class TestTextUtils:
         # Technical terms
         assert count_syllables("API") == 3
         assert count_syllables("GUI") == 2
+
+    def test_count_syllables_numbers_with_punctuation(self):
+        """Digits with commas or decimals should count each digit."""
+        assert count_syllables("1,234") == 4
+        assert count_syllables("123.45") == 5
 
     def test_normalize_heading_edge_cases(self):
         """Test heading normalization with edge cases."""


### PR DESCRIPTION
## Summary
- handle numbers with commas/decimals in word and syllable counters
- detect passive voice without explicit agent
- add regression tests for numeric tokens and passive voice

## Testing
- `python -m trace --count --summary --coverdir trace_cov --module pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bae9035d3c8332ac3f8554a79cc2b4