### PR TITLE
chore: bump axios to 1.12.0

### DIFF
--- a/frontend/govdocverify/package-lock.json
+++ b/frontend/govdocverify/package-lock.json
@@ -8,7 +8,7 @@
       "name": "govdocverify",
       "version": "0.0.0",
       "dependencies": {
-        "axios": "^1.9.0",
+        "axios": "^1.12.0",
         "classnames": "^2.5.1",
         "dompurify": "^3.0.0",
         "react": "^18.2.0",
@@ -2252,8 +2252,8 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
       "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "license": "MIT",
       "dependencies": {

--- a/frontend/govdocverify/package.json
+++ b/frontend/govdocverify/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "axios": "^1.9.0",
+    "axios": "^1.12.0",
     "classnames": "^2.5.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@emotion/styled": "^11.14.0",
         "@mui/icons-material": "^7.1.0",
         "@mui/material": "^7.1.2",
-        "axios": "^1.11.0"
+        "axios": "^1.12.0"
       },
       "devDependencies": {
         "@types/axios": "^0.9.36"
@@ -627,8 +627,8 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
       "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^7.1.0",
     "@mui/material": "^7.1.2",
-    "axios": "^1.11.0"
+    "axios": "^1.12.0"
   },
   "devDependencies": {
     "@types/axios": "^0.9.36"


### PR DESCRIPTION
## Summary
- update axios to 1.12.0 in root and frontend packages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm test --prefix frontend/govdocverify` *(fails: Missing script: "test")*
- `pytest`
- `pre-commit run --files package.json package-lock.json frontend/govdocverify/package.json frontend/govdocverify/package-lock.json` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c5b766c6d08332868b5d134d0e83a8