### PR TITLE
Fix utility edge cases and strengthen tests

### DIFF
--- a/govdocverify/utils/network.py
+++ b/govdocverify/utils/network.py
@@ -9,6 +9,8 @@ from govdocverify.utils.decorators import retry_transient
 
 try:
     DEFAULT_TIMEOUT = float(os.getenv("GOVDOCVERIFY_HTTP_TIMEOUT", "5"))
+    if DEFAULT_TIMEOUT <= 0:
+        raise ValueError
 except ValueError:
     DEFAULT_TIMEOUT = 5.0
 

--- a/govdocverify/utils/security.py
+++ b/govdocverify/utils/security.py
@@ -116,6 +116,11 @@ class RateLimiter:
             if not self.requests[cid]:
                 del self.requests[cid]
 
+        # A ``max_requests`` value of 0 or less disables rate limiting while still
+        # performing the cleanup above.
+        if self.max_requests <= 0:
+            return False
+
         # Add new request for this client
         self.requests.setdefault(client_id, []).append(current_time)
 

--- a/src/govdocverify/utils/network.py
+++ b/src/govdocverify/utils/network.py
@@ -9,6 +9,8 @@ from govdocverify.utils.decorators import retry_transient
 
 try:
     DEFAULT_TIMEOUT = float(os.getenv("GOVDOCVERIFY_HTTP_TIMEOUT", "5"))
+    if DEFAULT_TIMEOUT <= 0:
+        raise ValueError
 except ValueError:
     DEFAULT_TIMEOUT = 5.0
 

--- a/src/govdocverify/utils/security.py
+++ b/src/govdocverify/utils/security.py
@@ -115,6 +115,11 @@ class RateLimiter:
             if not self.requests[cid]:
                 del self.requests[cid]
 
+        # A ``max_requests`` value of 0 or less disables rate limiting while still
+        # performing the cleanup above.
+        if self.max_requests <= 0:
+            return False
+
         # Add new request for this client
         self.requests.setdefault(client_id, []).append(current_time)
 

--- a/src/govdocverify/utils/text_utils.py
+++ b/src/govdocverify/utils/text_utils.py
@@ -215,31 +215,28 @@ def count_words(text: str) -> int:
     if not text:
         logger.debug("count_words: empty input -> 0")
         return 0
-    # Treat underscores as spaces so ``snake_case`` counts as two words.
-    text = text.replace("_", " ")
     email_pattern = r"[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}"
     emails = list(re.finditer(email_pattern, text))
     email_count = len(emails)
+
+    # Remove e‑mail addresses before normalising underscores so addresses like
+    # ``first_last@example.com`` remain intact and are counted once.
+    text_wo_emails = re.sub(email_pattern, " ", text)
+    text_normalised = text_wo_emails.replace("_", " ")
+
     # Use an explicit character class that excludes underscores to split tokens
     # like ``snake_case`` into separate words.
     word_pattern = r"\b(?:-?\d{1,3}(?:,\d{3})*(?:\.\d+)?|[A-Za-z0-9]+(?:['-][A-Za-z0-9]+)*)\b"
 
-    if email_count == 0:
-        words = [w for w in re.findall(word_pattern, text) if re.search(r"[a-zA-Z0-9]", w)]
-        logger.debug(
-            f"count_words: input='{text}' emails=0 words={words} total={len(words)}"
-        )
-        return len(words)
-    # Strip e‑mails and count remaining words.
-    text_wo_emails = re.sub(email_pattern, " ", text)
     words = [
-        w for w in re.findall(word_pattern, text_wo_emails) if re.search(r"[a-zA-Z0-9]", w)
+        w for w in re.findall(word_pattern, text_normalised) if re.search(r"[a-zA-Z0-9]", w)
     ]
     logger.debug(
-        f"count_words: input='{text}', "
-        f"emails found={[m.group(0) for m in emails]}, "
-        f"words without emails={words}, "
-        f"total count={email_count + len(words)}"
+        "count_words: input='%s', emails found=%s, words without emails=%s, total=%d",
+        text,
+        [m.group(0) for m in emails],
+        words,
+        email_count + len(words),
     )
     return email_count + len(words)
 
@@ -341,8 +338,12 @@ def split_into_sentences(text: str) -> List[str]:
     return [s.strip() for s in sentences if s.strip()]
 
 
-def normalize_document_type(doc_type: str) -> str:
-    """Normalize document type string."""
+def normalize_document_type(doc_type: str | None) -> str:
+    """Normalize document type string.
+
+    ``None`` or empty inputs return an empty string instead of raising."""
+    if not doc_type:
+        return ""
     cleaned = doc_type.replace("_", " ").replace("-", " ")
     return " ".join(word.capitalize() for word in cleaned.lower().split())
 

--- a/tests/test_network_timeout.py
+++ b/tests/test_network_timeout.py
@@ -25,3 +25,11 @@ def test_invalid_timeout_env_uses_default(monkeypatch):
     sys.modules.pop("govdocverify.utils.network", None)
     module = importlib.import_module("govdocverify.utils.network")
     assert module.DEFAULT_TIMEOUT == 5.0
+
+
+def test_negative_timeout_env_uses_default(monkeypatch):
+    """Negative timeout values should fall back to the default."""
+    monkeypatch.setenv("GOVDOCVERIFY_HTTP_TIMEOUT", "-10")
+    sys.modules.pop("govdocverify.utils.network", None)
+    module = importlib.import_module("govdocverify.utils.network")
+    assert module.DEFAULT_TIMEOUT == 5.0

--- a/tests/test_security_utils.py
+++ b/tests/test_security_utils.py
@@ -91,3 +91,10 @@ def test_rate_limiter_prunes_stale_clients() -> None:
     limiter.requests["old"] = [time.time() - 2]
     limiter.is_rate_limited("new")
     assert "old" not in limiter.requests
+
+
+def test_rate_limiter_zero_disables() -> None:
+    """A max_requests value of 0 should disable limiting."""
+    limiter = RateLimiter(max_requests=0, time_window=1)
+    assert not limiter.is_rate_limited("a")
+    assert not limiter.is_rate_limited("a")

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -111,6 +111,12 @@ class TestTextUtils:
         assert count_words("snake_case") == 2
         assert count_words("mixed_snake_case example") == 4
 
+    def test_count_words_email_with_underscore(self):
+        """Emails containing underscores should count as a single word."""
+        text = "Contact first_last@example.com for info"
+        # Expected words: Contact, first_last@example.com, for, info -> 4
+        assert count_words(text) == 4
+
     def test_count_words_includes_common_stopwords(self):
         """Previously excluded words like 'to' and 'or' should be counted."""
         assert count_words("to be or not to be") == 6
@@ -132,6 +138,10 @@ class TestTextUtils:
         """Underscores should be treated as word separators."""
         assert normalize_reference("Example_With_Underscores") == "example with underscores"
         assert normalize_reference("Test/Reference\\Path") == "test reference path"
+
+    def test_normalize_document_type_none(self):
+        """None input should produce empty string instead of raising."""
+        assert normalize_document_type(None) == ""
 
     def test_count_syllables(self):
         """Test syllable counting."""


### PR DESCRIPTION
## Summary
- handle emails with underscores in word counting
- allow disabling rate limits with zero max_requests
- ignore non-positive network timeouts via env var
- normalize document type gracefully for None inputs

## Testing
- `pytest tests/test_text_utils.py::TestTextUtils::test_count_words_email_with_underscore tests/test_text_utils.py::TestTextUtils::test_normalize_document_type_none -q`
- `pytest tests/test_security_utils.py::test_rate_limiter_zero_disables -q`
- `pytest tests/test_network_timeout.py::test_negative_timeout_env_uses_default -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c603724ffc8332a1f021cd7f645462