### PR TITLE
Fix formatting and URL parsing edge cases

### DIFF
--- a/govdocverify/checks/format_checks.py
+++ b/govdocverify/checks/format_checks.py
@@ -435,12 +435,14 @@ class FormatChecks(BaseChecker):
     def _check_reference_formatting(self, content: List[str]) -> List[Dict]:
         """Check reference formatting."""
         warnings = []
-        reference_pattern = (
-            r"(?i)(see|refer to|under)\s+(section|paragraph|subsection)\s+\d+(\.\d+)*"
+        pattern = re.compile(
+            r"(see|refer to|under)\s+(section|paragraph|subsection)\s+\d+(?:\.\d+)*",
+            re.IGNORECASE,
         )
 
         for i, line in enumerate(content, 1):
-            if re.search(reference_pattern, line):
+            m = pattern.search(line)
+            if m and (m.group(1).islower() or m.group(2).islower()):
                 warnings.append(
                     {
                         "line_number": i,
@@ -458,7 +460,8 @@ class FormattingChecker(BaseChecker):
     # ── spacing helpers ──────────────────────────────────────────────────────
     _DOUBLE_SPACE_RE = re.compile(r" {2,}")
     _MISSING_SPACE_REF_RE = re.compile(
-        r"(?<!\s)(?P<prefix>(AC|AD|CFR|FAA|N|SFAR|Part))" r"(?P<number>\d+(?:[-]\d+)?[A-Z]?)"
+        r"\b(?P<prefix>(AC|AD|CFR|FAA|N|SFAR|Part))"
+        r"(?P<number>\d+(?:[-.]\d+)*(?:[A-Z])?)"
     )
 
     def check_text(self, content: str) -> DocumentCheckResult:

--- a/govdocverify/utils/link_utils.py
+++ b/govdocverify/utils/link_utils.py
@@ -28,6 +28,7 @@ def find_urls(text: str) -> Iterator[Tuple[str, Tuple[int, int]]]:
     def _strip_trailing(url: str) -> str:
         punctuation = ".,;:!?"  # characters always stripped
         brackets = {")": "(", "]": "[", "}": "{", "'": "'", '"': '"'}
+        openers = set(brackets.values())
 
         while url:
             last = url[-1]
@@ -46,6 +47,9 @@ def find_urls(text: str) -> Iterator[Tuple[str, Tuple[int, int]]]:
                 if url.count(last) > url.count(opener):
                     url = url[:-1]
                     continue
+            if last in openers:
+                url = url[:-1]
+                continue
             break
         return url
 

--- a/src/govdocverify/checks/format_checks.py
+++ b/src/govdocverify/checks/format_checks.py
@@ -446,12 +446,14 @@ class FormatChecks(BaseChecker):
     def _check_reference_formatting(self, content: List[str]) -> List[Dict]:
         """Check reference formatting."""
         warnings = []
-        reference_pattern = (
-            r"(?i)(see|refer to|under)\s+(section|paragraph|subsection)\s+\d+(\.\d+)*"
+        pattern = re.compile(
+            r"(see|refer to|under)\s+(section|paragraph|subsection)\s+\d+(?:\.\d+)*",
+            re.IGNORECASE,
         )
 
         for i, line in enumerate(content, 1):
-            if re.search(reference_pattern, line):
+            m = pattern.search(line)
+            if m and (m.group(1).islower() or m.group(2).islower()):
                 warnings.append(
                     {
                         "line_number": i,
@@ -469,7 +471,8 @@ class FormattingChecker(BaseChecker):
     # ── spacing helpers ──────────────────────────────────────────────────────
     _DOUBLE_SPACE_RE = re.compile(r" {2,}")
     _MISSING_SPACE_REF_RE = re.compile(
-        r"(?<!\s)(?P<prefix>(AC|AD|CFR|FAA|N|SFAR|Part))" r"(?P<number>\d+(?:[-]\d+)?[A-Z]?)"
+        r"\b(?P<prefix>(AC|AD|CFR|FAA|N|SFAR|Part))"
+        r"(?P<number>\d+(?:[-.]\d+)*(?:[A-Z])?)"
     )
 
     def check_text(self, content: str) -> DocumentCheckResult:

--- a/src/govdocverify/utils/link_utils.py
+++ b/src/govdocverify/utils/link_utils.py
@@ -27,6 +27,7 @@ def find_urls(text: str) -> Iterator[Tuple[str, Tuple[int, int]]]:
     def _strip_trailing(url: str) -> str:
         punctuation = ".,;:!?"  # characters always stripped
         brackets = {")": "(", "]": "[", "}": "{", "'": "'", '"': '"'}
+        openers = set(brackets.values())
 
         while url:
             last = url[-1]
@@ -47,6 +48,9 @@ def find_urls(text: str) -> Iterator[Tuple[str, Tuple[int, int]]]:
                 if url.count(last) > url.count(opener):
                     url = url[:-1]
                     continue
+            if last in openers:
+                url = url[:-1]
+                continue
             break
         return url
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -90,6 +90,25 @@ class TestFormattingChecks:
         ]
         assert warnings == [4]
 
+    def test_missing_space_in_regulatory_references(self):
+        """VR-02: missing spaces in references should be detected."""
+        lines = ["Refer to AC25.1309 for details", "Proper AC 25.1309 usage"]
+        checker = FormattingChecker()
+        result = checker.check_spacing(lines)
+        assert {issue["line_number"] for issue in result.issues} == {1}
+        assert any("ac" in issue["message"].lower() for issue in result.issues)
+
+    def test_reference_formatting_only_flags_incorrect_cases(self):
+        """VR-07: only lowercase references are flagged."""
+        content = [
+            "See Section 1 for details.",
+            "refer to section 2 for more.",
+            "Refer to Section 3 for context.",
+        ]
+        result = self.format_checks.check(content)
+        warnings = [w for w in result["warnings"] if "reference format" in w["message"].lower()]
+        assert {w["line_number"] for w in warnings} == {2}
+
     def test_list_formatting(self):
         content = [
             "The following items are required:",
@@ -136,9 +155,12 @@ class TestFormattingChecks:
         ]
         result = self.format_checks.check(content)
         assert not result["has_errors"]
-        assert any(
-            "inconsistent reference" in issue["message"].lower() for issue in result["warnings"]
-        )
+        warnings = [
+            w["line_number"]
+            for w in result["warnings"]
+            if "reference format" in w["message"].lower()
+        ]
+        assert warnings == [1, 2]
 
     def test_figure_formatting(self):
         content = [

--- a/tests/test_utils_updates.py
+++ b/tests/test_utils_updates.py
@@ -93,6 +93,12 @@ def test_find_urls_strips_closing_brackets() -> None:
     assert urls == ["https://example.gov/test", "https://example.gov/again"]
 
 
+def test_find_urls_strips_opening_brackets() -> None:
+    text = "See https://example.gov/test( for details"
+    urls = [u for u, _ in find_urls(text)]
+    assert urls == ["https://example.gov/test"]
+
+
 def test_find_urls_preserves_uppercase_scheme() -> None:
     text = "Visit HTTPS://Example.gov/ for info"
     urls = [u for u, _ in find_urls(text)]


### PR DESCRIPTION
## Summary
- improve regulatory reference spacing detection
- refine reference-format check to only flag lowercase "see section" phrases
- strip stray opening brackets from discovered URLs

## Testing
- `pytest -q`
- `python -m trace --count --summary --module pytest -- -q`

------
https://chatgpt.com/codex/tasks/task_e_68c608b6fd0c83329ae5da49fc08d6be