### PR TITLE
fix: address formatter and text utility issues

### DIFF
--- a/govdocverify/utils/formatting.py
+++ b/govdocverify/utils/formatting.py
@@ -166,6 +166,18 @@ class ResultFormatter:
         # Fallback for other issue formats
         return f"    • {str(issue)}"
 
+    def _resolve_check_name(self, result: Any) -> str:
+        """Return a friendly check name for display purposes."""
+        if hasattr(result, "checker_name") and getattr(result, "checker_name"):
+            return str(getattr(result, "checker_name"))
+        if hasattr(result, "check_name") and getattr(result, "check_name"):
+            return str(getattr(result, "check_name"))
+        if isinstance(result, dict):
+            name = result.get("checker_name") or result.get("check_name")
+            if name:
+                return str(name)
+        return "General"
+
     def _format_accessibility_issues(self, result: DocumentCheckResult) -> List[str]:
         """Format accessibility-specific issues."""
         formatted_issues = []
@@ -400,7 +412,7 @@ class ResultFormatter:
             for result, issues in category_data:
                 for issue in issues:
                     message = issue.get("message") or issue.get("error", str(issue))
-                    check_name = getattr(result, "check_name", "General")
+                    check_name = self._resolve_check_name(result)
                     span_style = "color: #721c24; font-weight: bold;"
                     check_display = check_name.replace("_", " ").title()
                     li_content = (
@@ -424,7 +436,7 @@ class ResultFormatter:
             for result, issues in category_data:
                 for issue in issues:
                     message = issue.get("message") or issue.get("error", str(issue))
-                    check_name = getattr(result, "check_name", "General")
+                    check_name = self._resolve_check_name(result)
                     check_label = self._format_colored_text(
                         f"[{check_name.replace('_', ' ').title()}]", Fore.RED
                     )

--- a/src/govdocverify/utils/formatting.py
+++ b/src/govdocverify/utils/formatting.py
@@ -166,6 +166,18 @@ class ResultFormatter:
         # Fallback for other issue formats
         return f"    • {str(issue)}"
 
+    def _resolve_check_name(self, result: Any) -> str:
+        """Return a friendly check name for display purposes."""
+        if hasattr(result, "checker_name") and getattr(result, "checker_name"):
+            return str(getattr(result, "checker_name"))
+        if hasattr(result, "check_name") and getattr(result, "check_name"):
+            return str(getattr(result, "check_name"))
+        if isinstance(result, dict):
+            name = result.get("checker_name") or result.get("check_name")
+            if name:
+                return str(name)
+        return "General"
+
     def _format_accessibility_issues(self, result: DocumentCheckResult) -> List[str]:
         """Format accessibility-specific issues."""
         formatted_issues = []
@@ -400,7 +412,7 @@ class ResultFormatter:
             for result, issues in category_data:
                 for issue in issues:
                     message = issue.get("message") or issue.get("error", str(issue))
-                    check_name = getattr(result, "check_name", "General")
+                    check_name = self._resolve_check_name(result)
                     span_style = "color: #721c24; font-weight: bold;"
                     check_display = check_name.replace("_", " ").title()
                     li_content = (
@@ -424,7 +436,7 @@ class ResultFormatter:
             for result, issues in category_data:
                 for issue in issues:
                     message = issue.get("message") or issue.get("error", str(issue))
-                    check_name = getattr(result, "check_name", "General")
+                    check_name = self._resolve_check_name(result)
                     check_label = self._format_colored_text(
                         f"[{check_name.replace('_', ' ').title()}]", Fore.RED
                     )

--- a/src/govdocverify/utils/text_utils.py
+++ b/src/govdocverify/utils/text_utils.py
@@ -16,6 +16,20 @@ class SentenceContext(TypedDict):
     text: str
 
 
+_KNOWN_ACRONYMS: Set[str] | None = None
+
+
+def _get_known_acronyms() -> Set[str]:
+    """Return cached set of standard and custom acronyms."""
+    global _KNOWN_ACRONYMS
+    if _KNOWN_ACRONYMS is None:
+        manager = TerminologyManager()
+        acronyms = set(manager.get_standard_acronyms().keys())
+        acronyms.update(manager.get_custom_acronyms().keys())
+        _KNOWN_ACRONYMS = acronyms
+    return _KNOWN_ACRONYMS
+
+
 def split_sentences(text: str) -> List[str]:
     """
     Split text into sentences while handling common abbreviations,
@@ -344,8 +358,17 @@ def normalize_document_type(doc_type: str | None) -> str:
     ``None`` or empty inputs return an empty string instead of raising."""
     if not doc_type:
         return ""
-    cleaned = doc_type.replace("_", " ").replace("-", " ")
-    return " ".join(word.capitalize() for word in cleaned.lower().split())
+    tokens = re.split(r"[\s_-]+", doc_type.strip())
+    known_acronyms = _get_known_acronyms()
+    words: List[str] = []
+    for token in tokens:
+        if not token:
+            continue
+        if token.isupper() and (len(token) <= 3 or token in known_acronyms):
+            words.append(token)
+        else:
+            words.append(token.lower().capitalize())
+    return " ".join(words)
 
 
 def calculate_readability_metrics(
@@ -397,9 +420,9 @@ def calculate_passive_voice_percentage(text: str) -> float:
         return 0.0
 
     passive_patterns = [
-        r"\b(?:am|is|are|was|were|be|been|being)\s+\w+(?:ed|en|wn)\s+by\b",
-        r"\b(?:has|have|had)\s+been\s+\w+(?:ed|en|wn)\b",
-        r"\b(?:am|is|are|was|were|be|been|being)\s+\w{4,}(?:ed|en|wn)\b",
+        r"\b(?:am|is|are|was|were|be|been|being)\s+(?=\w{4,}\b)\w*(?:ed|en|wn|ne)\s+by\b",
+        r"\b(?:has|have|had)\s+been\s+(?=\w{4,}\b)\w*(?:ed|en|wn|ne)\b",
+        r"\b(?:am|is|are|was|were|be|been|being)\s+(?=\w{4,}\b)\w*(?:ed|en|wn|ne)\b",
     ]
     passive_regex = re.compile("|".join(passive_patterns), re.IGNORECASE)
     passive_count = sum(1 for sentence in sentences if passive_regex.search(sentence))

--- a/tests/test_result_formatter.py
+++ b/tests/test_result_formatter.py
@@ -101,6 +101,18 @@ def test_format_results_unknown_group():
     assert "Internal error" in text
 
 
+def test_format_results_includes_checker_name_labels():
+    """Checker names should appear in category output instead of 'General'."""
+    result = DocumentCheckResult(success=False, checker_name="heading_checks")
+    result.add_issue("Heading issue", Severity.ERROR)
+    data = {"headings": {"heading_checks": result}}
+
+    fmt = ResultFormatter(style=FormatStyle.PLAIN)
+    text = fmt.format_results(data, "AC")
+
+    assert "Heading Checks" in text
+
+
 def test_format_results_with_metadata():
     result = _make_result()
     data = {"x": {"y": result}}

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -143,6 +143,11 @@ class TestTextUtils:
         """None input should produce empty string instead of raising."""
         assert normalize_document_type(None) == ""
 
+    def test_normalize_document_type_preserves_acronyms(self):
+        """Uppercase acronyms should remain uppercase when normalised."""
+        assert normalize_document_type("FAA ORDER") == "FAA Order"
+        assert normalize_document_type("NASA memorandum") == "NASA Memorandum"
+
     def test_count_syllables(self):
         """Test syllable counting."""
         # Basic words
@@ -217,6 +222,11 @@ class TestTextUtils:
     def test_calculate_passive_voice_percentage_without_by(self):
         """Sentences in passive voice without an explicit agent are detected."""
         text = "The report was completed. The team reviewed it."
+        assert calculate_passive_voice_percentage(text) == 50.0
+
+    def test_calculate_passive_voice_percentage_handles_common_participles(self):
+        """Past participles like 'done' should register as passive voice."""
+        text = "The work was done. The team celebrated."
         assert calculate_passive_voice_percentage(text) == 50.0
 
     def test_extract_acronyms(self):


### PR DESCRIPTION
## Summary
- preserve uppercase acronyms when normalizing document types and recognize additional passive constructions
- ensure result formatter respects checker_name values when rendering category sections
- add regression tests for document type normalization, passive voice detection, and formatter labels

## Testing
- `pytest -q`
- `python -m trace --count --coverdir trace_cov --module pytest -- -q`


------
https://chatgpt.com/codex/tasks/task_e_68cdf0289cc48332825dd92c5754b234