### PR TITLE
fix(utils): handle whitespace and punctuation edge cases

### DIFF
--- a/govdocverify/utils/metadata_utils.py
+++ b/govdocverify/utils/metadata_utils.py
@@ -20,6 +20,8 @@ def extract_docx_metadata(file_path: str) -> Dict[str, Any]:
         Dictionary containing metadata fields such as title, author, and
         last modified by. Empty values are omitted.
     """
+    file_path = file_path.strip()
+
     if not file_path.lower().endswith(".docx"):
         return {}
     try:

--- a/govdocverify/utils/security.py
+++ b/govdocverify/utils/security.py
@@ -187,17 +187,22 @@ def _is_allowed_domain(domain: str) -> bool:
 
 def _validate_extension(ext: str) -> None:
     """Validate a file extension against allowed and legacy lists."""
+    ext = ext.strip()
     if not ext:
         raise SecurityError("Missing file extension")
-    if ext in LEGACY_FILE_EXTENSIONS:
+    normalized = ext.lower()
+    allowed_exts = {value.lower() for value in ALLOWED_FILE_EXTENSIONS}
+    legacy_exts = {value.lower() for value in LEGACY_FILE_EXTENSIONS}
+    if normalized in legacy_exts:
         raise SecurityError(f"Legacy file format: {ext}")
-    if ext not in ALLOWED_FILE_EXTENSIONS:
+    if normalized not in allowed_exts:
         raise SecurityError(f"Disallowed file format: {ext}")
 
 
 def validate_source(path: str) -> None:
     """Validate that ``path`` is from an approved domain and format."""
 
+    path = path.strip()
     lowered = path.lower()
 
     # Handle Windows drive paths like ``C:\\path\\file.docx`` which ``urlparse``

--- a/src/govdocverify/utils/metadata_utils.py
+++ b/src/govdocverify/utils/metadata_utils.py
@@ -20,6 +20,8 @@ def extract_docx_metadata(file_path: str) -> Dict[str, Any]:
         Dictionary containing metadata fields such as title, author, and
         last modified by. Empty values are omitted.
     """
+    file_path = file_path.strip()
+
     if not file_path.lower().endswith(".docx"):
         return {}
     try:

--- a/src/govdocverify/utils/security.py
+++ b/src/govdocverify/utils/security.py
@@ -189,6 +189,7 @@ def _is_allowed_domain(domain: str) -> bool:
 def validate_source(path: str) -> None:
     """Validate that ``path`` is from an approved domain and format."""
 
+    path = path.strip()
     lowered = path.lower()
 
     # Separate any URL components before extracting the extension.  The
@@ -197,6 +198,11 @@ def validate_source(path: str) -> None:
     # (e.g. ``".docx?download=1"``) and valid URLs were rejected.
     parsed = urlparse(lowered)
     _, ext = os.path.splitext(parsed.path)
+    ext = ext.strip()
+    normalized_ext = ext.lower()
+
+    allowed_exts = {value.lower() for value in ALLOWED_FILE_EXTENSIONS}
+    legacy_exts = {value.lower() for value in LEGACY_FILE_EXTENSIONS}
 
     # Permit bare local paths without extension or URL components.  All other
     # forms must include an extension for validation.
@@ -204,9 +210,9 @@ def validate_source(path: str) -> None:
         return
     if not ext:
         raise SecurityError("Missing file extension")
-    if ext in LEGACY_FILE_EXTENSIONS:
+    if normalized_ext in legacy_exts:
         raise SecurityError(f"Legacy file format: {ext}")
-    if ext not in ALLOWED_FILE_EXTENSIONS:
+    if normalized_ext not in allowed_exts:
         raise SecurityError(f"Disallowed file format: {ext}")
 
     if parsed.scheme and parsed.netloc and parsed.scheme not in {"http", "https"}:

--- a/src/govdocverify/utils/text_utils.py
+++ b/src/govdocverify/utils/text_utils.py
@@ -358,16 +358,28 @@ def normalize_document_type(doc_type: str | None) -> str:
     ``None`` or empty inputs return an empty string instead of raising."""
     if not doc_type:
         return ""
-    tokens = re.split(r"[\s_-]+", doc_type.strip())
+    cleaned = re.sub(r"[\\/]+", " ", doc_type.strip())
+    tokens = re.split(r"[\s_-]+", cleaned)
     known_acronyms = _get_known_acronyms()
     words: List[str] = []
     for token in tokens:
         if not token:
             continue
-        if token.isupper() and (len(token) <= 3 or token in known_acronyms):
-            words.append(token)
-        else:
-            words.append(token.lower().capitalize())
+        parts = [token]
+        if "." in token:
+            dotted_acronym = re.fullmatch(r"[A-Za-z](?:\.[A-Za-z]+)+\.?", token)
+            numeric_sequence = re.fullmatch(r"\d+(?:\.\d+)+", token)
+            if not dotted_acronym and not numeric_sequence:
+                parts = [p for p in token.split(".") if p]
+        for part in parts:
+            if not part:
+                continue
+            if part.isupper():
+                vowel_count = sum(1 for ch in part if ch in "AEIOU")
+                if len(part) <= 3 or part in known_acronyms or vowel_count <= 1:
+                    words.append(part)
+                    continue
+            words.append(part.lower().capitalize())
     return " ".join(words)
 
 

--- a/tests/test_metadata_utils.py
+++ b/tests/test_metadata_utils.py
@@ -20,6 +20,16 @@ def test_extract_docx_metadata(tmp_path: Path) -> None:
     assert meta["last_modified_by"] == "Bob"
 
 
+def test_extract_docx_metadata_ignores_surrounding_whitespace(tmp_path: Path) -> None:
+    doc = Document()
+    doc.core_properties.title = "Whitespace"
+    file_path = tmp_path / "meta.docx"
+    doc.save(file_path)
+
+    meta = extract_docx_metadata(f"  {file_path}  ")
+    assert meta["title"] == "Whitespace"
+
+
 def test_extract_docx_metadata_created_modified(tmp_path: Path) -> None:
     """Verify `created` and `modified` metadata are extracted."""
     doc = Document()

--- a/tests/test_security_utils.py
+++ b/tests/test_security_utils.py
@@ -86,6 +86,11 @@ def test_validate_source_allows_scheme_less_domain() -> None:
     validate_source("agency.gov/file.docx")
 
 
+def test_validate_source_trims_whitespace() -> None:
+    """Surrounding whitespace should not cause valid sources to fail."""
+    validate_source("  https://agency.gov/file.docx  ")
+
+
 def test_rate_limiter_prunes_stale_clients() -> None:
     limiter = RateLimiter(max_requests=1, time_window=1)
     limiter.requests["old"] = [time.time() - 2]

--- a/tests/test_text_utils.py
+++ b/tests/test_text_utils.py
@@ -382,6 +382,11 @@ class TestTextUtils:
         assert normalize_document_type("policy-statement") == "Policy Statement"
         assert normalize_document_type("policy_statement") == "Policy Statement"
 
+    def test_normalize_document_type_with_embedded_punctuation(self):
+        """Embedded punctuation should behave like separators."""
+        assert normalize_document_type("policy.statement") == "Policy Statement"
+        assert normalize_document_type("FAA/ASTM standard") == "FAA ASTM Standard"
+
     def test_calculate_readability_metrics(self):
         metrics = calculate_readability_metrics(100, 10, 150)
         assert "flesch_reading_ease" in metrics


### PR DESCRIPTION
## Summary
- trim whitespace before validating sources and normalise extension comparisons in both utility modules
- strip file paths before extracting DOCX metadata so surrounding spaces do not hide valid files
- improve document-type normalisation to treat punctuation as separators while preserving acronyms and add targeted tests

## Testing
- pytest -q
- python -m trace --count --summary --module pytest -- -q

------
https://chatgpt.com/codex/tasks/task_e_68cdf5964ba483329b2ad0a68def7301