### PR TITLE
fix(models): normalise severity handling

### DIFF
--- a/govdocverify/checks/format_checks.py
+++ b/govdocverify/checks/format_checks.py
@@ -87,8 +87,8 @@ class FormatMessages:
         "or similar formatting to keep lines together."
     )
     HEADING_FOLLOWED_BY_BLANK_WARNING = (
-        "Heading is followed by an empty paragraph. Remove the blank paragraph and use 'Keep with next' "
-        "to keep the heading with its content."
+        "Heading is followed by an empty paragraph. Remove the blank paragraph "
+        "and use 'Keep with next' to keep the heading with its content."
     )
 
 
@@ -492,9 +492,14 @@ class FormatChecks(BaseChecker):
                 previous_blank = False
 
             # Manual line break characters inside headings
-            if ("\n" in line or "\r" in line) and self._looks_like_heading(line.splitlines()[0].strip()):
+            has_manual_break = "\n" in line or "\r" in line
+            if has_manual_break and self._looks_like_heading(line.splitlines()[0].strip()):
                 # Only warn when a heading paragraph is manually split from its body text
-                segments = [segment.strip() for segment in re.split(r"[\r\n]+", line) if segment.strip()]
+                segments = [
+                    segment.strip()
+                    for segment in re.split(r"[\r\n]+", line)
+                    if segment.strip()
+                ]
                 if len(segments) >= 2 and self._looks_like_heading(segments[0]):
                     warnings.append(
                         {

--- a/src/govdocverify/models/__init__.py
+++ b/src/govdocverify/models/__init__.py
@@ -118,6 +118,34 @@ class DocumentCheckResult:
                 )
         # Preserve any severity supplied by the caller instead of resetting it
         # to ``None``. It will still be updated when new issues are added.
+        self.severity = self._parse_severity(self.severity)
+        for issue in self.issues:
+            parsed = self._parse_severity(issue.get("severity"))
+            issue["severity"] = parsed if parsed is not None else Severity.WARNING
+
+    @staticmethod
+    def _parse_severity(value: Any) -> Optional[Severity]:
+        if value is None:
+            return None
+        if isinstance(value, Severity):
+            return value
+        if isinstance(value, int):
+            try:
+                return Severity(value)
+            except ValueError:
+                return None
+        if isinstance(value, str):
+            candidate = value.strip()
+            if not candidate:
+                return None
+            try:
+                return Severity[candidate.replace(" ", "_").upper()]
+            except KeyError:
+                try:
+                    return Severity(int(candidate))
+                except (ValueError, KeyError):
+                    return None
+        return None
 
     def add_issue(
         self,
@@ -181,9 +209,10 @@ class DocumentCheckResult:
         issues: List[Dict[str, Any]] = []
         for issue in self.issues:
             new_issue = issue.copy()
-            sev = new_issue.get("severity")
-            if isinstance(sev, Severity):
-                new_issue["severity"] = sev.value
+            sev = self._parse_severity(new_issue.get("severity"))
+            new_issue["severity"] = (
+                sev.value if isinstance(sev, Severity) else Severity.WARNING.value
+            )
             issues.append(new_issue)
 
         return {
@@ -213,25 +242,14 @@ class DocumentCheckResult:
         if version > cls.SERIALIZATION_VERSION:
             raise ValueError(f"Unsupported DocumentCheckResult version: {version}")
 
-        def _parse_severity(value: Any) -> Any:
-            if isinstance(value, Severity):
-                return value
-            if isinstance(value, int):
-                return Severity(value)
-            if isinstance(value, str):
-                try:
-                    return Severity[value.strip().replace(" ", "_").upper()]
-                except KeyError:
-                    pass
-            return value
-
         issues: List[Dict[str, Any]] = []
         for issue in data.get("issues", []):
             new_issue = issue.copy()
-            new_issue["severity"] = _parse_severity(new_issue.get("severity"))
+            parsed = cls._parse_severity(new_issue.get("severity"))
+            new_issue["severity"] = parsed if parsed is not None else Severity.WARNING
             issues.append(new_issue)
 
-        severity = _parse_severity(data.get("severity"))
+        severity = cls._parse_severity(data.get("severity"))
 
         return cls(
             success=data.get("success", True),

--- a/tests/test_models_root.py
+++ b/tests/test_models_root.py
@@ -27,6 +27,15 @@ def test_document_check_result_html() -> None:
     assert "warning" in html and "error" in html
 
 
+def test_document_check_result_html_handles_string_severity() -> None:
+    res = models.DocumentCheckResult(
+        issues=[{"message": "msg", "severity": "warning"}]
+    )
+    html = res.to_html()
+    assert "msg" in html
+    assert "warning" in html.lower()
+
+
 def test_visibility_settings_roundtrip() -> None:
     vis = models.VisibilitySettings(
         show_readability=False,
@@ -56,3 +65,6 @@ def test_document_check_result_preserves_initial_severity() -> None:
 
     res = DocumentCheckResult(success=True, severity=Severity.WARNING)
     assert res.severity == Severity.WARNING
+
+    legacy = models.DocumentCheckResult(success=True, severity=models.Severity.WARNING)
+    assert legacy.severity == models.Severity.WARNING

--- a/tests/test_serialization_versions.py
+++ b/tests/test_serialization_versions.py
@@ -29,3 +29,10 @@ def test_document_check_result_rejects_future_version() -> None:
     data = {"version": 999, "success": True, "issues": []}
     with pytest.raises(ValueError):
         DocumentCheckResult.from_dict(data)
+
+
+def test_document_check_result_html_accepts_string_severity() -> None:
+    res = DocumentCheckResult(issues=[{"message": "msg", "severity": "warning"}])
+    html = res.to_html()
+    assert "msg" in html
+    assert "warning" in html.lower()


### PR DESCRIPTION
## Summary
- split long format warning text and simplify heading break checks to satisfy lint without weakening behaviour
- normalise severity values in legacy and package DocumentCheckResult implementations to prevent crashes when strings/ints are provided and to preserve caller supplied severity
- align serialisation helpers with the new severity normalisation and extend tests to cover string severity handling for both legacy and current models

## Testing
- pytest -q
- python -m trace --module pytest -- -q


------
https://chatgpt.com/codex/tasks/task_e_68ddab7cc07483329bf03c3699d8f65a